### PR TITLE
Add exception for named blocks

### DIFF
--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -43,7 +43,13 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
           );
           return null;
         } else {
-          node.attributes.push(builders.attr(dataAttribute, builders.text('')));
+          if (node.tag.startsWith(':')) {
+            return node;
+          } else {
+            node.attributes.push(
+              builders.attr(dataAttribute, builders.text(''))
+            );
+          }
         }
       },
     },

--- a/test-app/app/components/outer.hbs
+++ b/test-app/app/components/outer.hbs
@@ -9,3 +9,5 @@
   Outer p.
 </p>
 <Inner />
+
+{{yield to="block"}}

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -1,5 +1,11 @@
 {{page-title "TestApp"}}
 
-<Outer />
+<Outer>
+  <:block>
+    <p>
+      Paragraph in a named block
+    </p>
+  </:block>
+</Outer>
 
 {{outlet}}


### PR DESCRIPTION
I encountered this trying to incorporate `glimmer-scoped-css` into `boxel-ui`:

```
Module build failed (from ../../../../../../../../../../../../Users/b/Documents/Cardstack/Code/boxel-motion/node_modules/.pnpm/thread-loader@3.0.4_webpack@5.75.0/node_modules/thread-loader/dist/cjs.js):
Thread Loader (Worker 2)
$TMPDIR/embroider/c50e3e/packages/boxel-ui/components/card-container/usage.js/usage.js: named block <:description> cannot have attributes, arguments, or modifiers:

|
|  <:description data-scopedcss-2fe13a34ac>
|          A wrapper container for a card.
|        </:description>
```

This PR changes the handler for `ElementNode` to skip adding `data-scopedcss…` attributes when `element.tag` starts with `:`, which indicates a named block.

Note that I am encountering this error on rebuilds in `boxel-ui` when using this fix; I don’t believe it has to do with this change but I can’t be sure of anything:

```
Build Error (WaitForTrees)

ENOTEMPTY: directory not empty, rmdir '/private/var/folders/34/1ldk02sx5ls7sdn1qvy5z2mr0000gn/T/embroider/c50e3e/packages/boxel-ui/lib/setup-ast-transforms/'
```

The initial build and render does work though:

<img width="403" alt="Boxel Components 2023-04-21 15-27-02" src="https://user-images.githubusercontent.com/43280/233728652-84eda965-722e-4a9a-be51-be92d161a53b.png">

<img width="387" alt="bm3 2023-04-21 15-27-53" src="https://user-images.githubusercontent.com/43280/233728767-95a7b64d-4d12-44f7-be8f-43d8e9a7a1b0.png">

<img width="320" alt="Boxel Components 2023-04-21 15-27-31" src="https://user-images.githubusercontent.com/43280/233728701-f6fc5d8d-ba58-4141-aadb-334e61d2d9fc.png">
