### PR TITLE
Add details on how to use within an addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ ember install glimmer-scoped-css
     });
    ```
 
+### In an Ember application
+
 2. Add an in-repo addon to install the Handlebars preprocessor:
 
    In `package.json`:
@@ -125,6 +127,28 @@ ember install glimmer-scoped-css
       },
     };
    ```
+
+### In an Ember addon
+
+2. Install the preprocessor directly in the addon’s `index.js`:
+
+   ```diff
+    'use strict'
+   +const { installScopedCSS } = require('glimmer-scoped-css');
+
+    module.exports = {
+      name: require('./package').name,
+      isDevelopingAddon() {
+        return true;
+      },
+   +  setupPreprocessorRegistry(type, registry) {
+   +    if (type === 'self') {
+   +      installScopedCSS(registry);
+   +    }
+   +  },
+    };
+   ```
+
 
 ## Usage
 


### PR DESCRIPTION
This approach bypasses an [Ember CLI/Embroider crash](https://github.com/cardstack/boxel/pull/306#issue-1681786005) when we tried to use it the boxel-ui addon, likely due to special handling for test dummy apps within addons. It may be possible to fix the deeper issue but in the meantime this works for an addon with a dummy app.