### PR TITLE
Add demonstration of tilde-comma bug

### DIFF
--- a/test-app/app/components/outer.hbs
+++ b/test-app/app/components/outer.hbs
@@ -1,5 +1,9 @@
 <style>
   p { color: blue; }
+
+  p ~ .something, h1 ~ .something {
+    display: none;
+  }
 </style>
 
 <h1 data-test-outer-h1>


### PR DESCRIPTION
There’s a strange bug where a block with two selectors with at least one tilde causes syntax errors in some circumstances.

<table>
<tr>
<td>

```css
  p ~ .something, h1 ~ .something {
    display: none;
  }
```
</td>
<td>

`CssSyntaxError: <css input>:4:31: Unclosed bracket`
</td>
</tr>
<tr>
<td>

```css
  p ~ .something, h1 {
    display: none;
  }
```
</td>
<td>☑️</td>
</tr>
<tr>
<td>

```css
  p, h1 ~ .something {
    display: none;
  }
```
</td>
<td>☑️</td>
</tr>
<tr>
<td>

```css
  p ~ .something, h3, h1 ~ .something {
    display: none;
  }
```
</td>
<td>☑️</td>
</tr>
<tr>
<td>

```css
  p + .something, h2 ~ .x, h1 + .something {
    display: none;
  }
```
</td>
<td>

`CssSyntaxError: <css input>:5:10: Unclosed bracket`
</td>
</tr>
</table>

Mysterious… I have also seen `Unknown word` and `Missed semicolon` errors.

Stacktrace selection:
```
Module build failed (from ../../../../../../../../../Users/b/Documents/Cardstack/Code/glimmer-scoped-css/glimmer-scoped-css/dist/virtual-loader.js):
CssSyntaxError: <css input>:5:10: Unclosed bracket
    at Input.error (/Users/b/Documents/Cardstack/Code/glimmer-scoped-css/node_modules/.pnpm/postcss@8.4.21/node_modules/postcss/lib/input.js:148:16)
    at Parser.unclosedBracket (/Users/b/Documents/Cardstack/Code/glimmer-scoped-css/node_modules/.pnpm/postcss@8.4.21/node_modules/postcss/lib/parser.js:532:22)
```

It’s not clear to me where the problem actually is, is it actually within this library?