### PR TITLE
Fix bug with incorrectly-encoded CSS

### DIFF
--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -34,7 +34,7 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
           // TODO: hard coding the loader chain means we ignore the other
           // prevailing rules (and we're even assuming these loaders are
           // available)
-          let encodedCssFilePath = btoa(textContent(node));
+          let encodedCssFilePath = encodeURIComponent(btoa(textContent(node)));
 
           jsutils.importForSideEffect(
             `style-loader!css-loader!glimmer-scoped-css/virtual-loader?file=${encodedCssFilePath}&selector=${dataAttribute}!`

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -34,10 +34,10 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
           // TODO: hard coding the loader chain means we ignore the other
           // prevailing rules (and we're even assuming these loaders are
           // available)
-          let encodedCssFilePath = encodeURIComponent(btoa(textContent(node)));
+          let encodedCss = encodeURIComponent(btoa(textContent(node)));
 
           jsutils.importForSideEffect(
-            `style-loader!css-loader!glimmer-scoped-css/virtual-loader?file=${encodedCssFilePath}&selector=${dataAttribute}!`
+            `style-loader!css-loader!glimmer-scoped-css/virtual-loader?file=${encodedCss}&selector=${dataAttribute}!`
           );
           return null;
         } else {

--- a/glimmer-scoped-css/src/virtual-loader.ts
+++ b/glimmer-scoped-css/src/virtual-loader.ts
@@ -3,33 +3,33 @@ import postcss from 'postcss';
 import scopedStylesPlugin from './postcss-plugin';
 
 export default function virtualLoader(this: LoaderContext<unknown>) {
-  let cssFileAndSelectorString = this.loaders[this.loaderIndex]?.options;
+  let encodedCssAndSelectorString = this.loaders[this.loaderIndex]?.options;
 
-  if (typeof cssFileAndSelectorString !== 'string') {
+  if (typeof encodedCssAndSelectorString !== 'string') {
     throw new Error(
-      `glimmer-scoped-css/src/virtual-loader received unexpected request: ${cssFileAndSelectorString}`
+      `glimmer-scoped-css/src/virtual-loader received unexpected request: ${encodedCssAndSelectorString}`
     );
   }
 
-  let cssFileAndSelector = new URLSearchParams(cssFileAndSelectorString);
+  let encodedCssAndSelector = new URLSearchParams(encodedCssAndSelectorString);
 
-  let cssFile = cssFileAndSelector.get('file');
+  let encodedCss = encodedCssAndSelector.get('file');
 
-  if (!cssFile) {
+  if (!encodedCss) {
     throw new Error(
-      `glimmer-scoped-css/src/virtual-loader missing file parameter: ${cssFileAndSelectorString}`
+      `glimmer-scoped-css/src/virtual-loader missing file parameter: ${encodedCssAndSelectorString}`
     );
   }
 
-  let cssSelector = cssFileAndSelector.get('selector');
+  let cssSelector = encodedCssAndSelector.get('selector');
 
   if (!cssSelector) {
     throw new Error(
-      `glimmer-scoped-css/src/virtual-loader missing selector parameter: ${cssFileAndSelectorString}`
+      `glimmer-scoped-css/src/virtual-loader missing selector parameter: ${encodedCssAndSelectorString}`
     );
   }
 
-  let cssSource = atob(decodeURIComponent(cssFile));
+  let cssSource = atob(decodeURIComponent(encodedCss));
   let result = postcss([scopedStylesPlugin(cssSelector)]).process(cssSource);
 
   return result.css;

--- a/glimmer-scoped-css/src/virtual-loader.ts
+++ b/glimmer-scoped-css/src/virtual-loader.ts
@@ -29,7 +29,7 @@ export default function virtualLoader(this: LoaderContext<unknown>) {
     );
   }
 
-  let cssSource = atob(cssFile);
+  let cssSource = atob(decodeURIComponent(cssFile));
   let result = postcss([scopedStylesPlugin(cssSelector)]).process(cssSource);
 
   return result.css;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,19 +97,19 @@ importers:
         version: 4.0.12(@babel/core@7.21.4)
       '@types/ember__controller':
         specifier: ^4.0.0
-        version: 4.0.4
+        version: 4.0.4(@babel/core@7.21.4)
       '@types/ember__debug':
         specifier: ^4.0.0
-        version: 4.0.3
+        version: 4.0.3(@babel/core@7.21.4)
       '@types/ember__engine':
         specifier: ^4.0.0
-        version: 4.0.4
+        version: 4.0.4(@babel/core@7.21.4)
       '@types/ember__error':
         specifier: ^4.0.0
         version: 4.0.2
       '@types/ember__object':
         specifier: ^4.0.0
-        version: 4.0.5
+        version: 4.0.5(@babel/core@7.21.4)
       '@types/ember__polyfills':
         specifier: ^4.0.0
         version: 4.0.1
@@ -121,7 +121,7 @@ importers:
         version: 4.0.2(@babel/core@7.21.4)
       '@types/ember__service':
         specifier: ^4.0.0
-        version: 4.0.2
+        version: 4.0.2(@babel/core@7.21.4)
       '@types/ember__string':
         specifier: ^3.16.0
         version: 3.16.3
@@ -384,7 +384,7 @@ importers:
         specifier: ^7.3.4
         version: 7.3.4(eslint@7.32.0)
       glimmer-scoped-css:
-        specifier: ^0.1.1
+        specifier: ^0.1.2
         version: link:../glimmer-scoped-css
       loader.js:
         specifier: ^4.7.0
@@ -3265,15 +3265,15 @@ packages:
       '@types/ember__application': 4.0.5(@babel/core@7.21.4)
       '@types/ember__array': 4.0.3(@babel/core@7.21.4)
       '@types/ember__component': 4.0.12(@babel/core@7.21.4)
-      '@types/ember__controller': 4.0.4
-      '@types/ember__debug': 4.0.3
-      '@types/ember__engine': 4.0.4
+      '@types/ember__controller': 4.0.4(@babel/core@7.21.4)
+      '@types/ember__debug': 4.0.3(@babel/core@7.21.4)
+      '@types/ember__engine': 4.0.4(@babel/core@7.21.4)
       '@types/ember__error': 4.0.2
-      '@types/ember__object': 4.0.5
+      '@types/ember__object': 4.0.5(@babel/core@7.21.4)
       '@types/ember__polyfills': 4.0.1
       '@types/ember__routing': 4.0.12(@babel/core@7.21.4)
       '@types/ember__runloop': 4.0.2(@babel/core@7.21.4)
-      '@types/ember__service': 4.0.2
+      '@types/ember__service': 4.0.2(@babel/core@7.21.4)
       '@types/ember__string': 3.16.3
       '@types/ember__template': 4.0.1
       '@types/ember__test': 4.0.1(@babel/core@7.21.4)
@@ -3304,8 +3304,8 @@ packages:
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.21.4)
       '@types/ember': 4.0.3(@babel/core@7.21.4)
-      '@types/ember__engine': 4.0.4
-      '@types/ember__object': 4.0.5
+      '@types/ember__engine': 4.0.4(@babel/core@7.21.4)
+      '@types/ember__object': 4.0.5(@babel/core@7.21.4)
       '@types/ember__owner': 4.0.3
       '@types/ember__routing': 4.0.12(@babel/core@7.21.4)
     transitivePeerDependencies:
@@ -3327,7 +3327,7 @@ packages:
     resolution: {integrity: sha512-G6kbLaS3ke4QspHkgLlGY0t1v0G22hGavyphezZucj7LLk1N+r11w913CYkBg3cJsJD+TG2Wo4eVbgRcotvuvQ==}
     dependencies:
       '@types/ember': 4.0.3(@babel/core@7.21.4)
-      '@types/ember__object': 4.0.5
+      '@types/ember__object': 4.0.5(@babel/core@7.21.4)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -3347,7 +3347,7 @@ packages:
     resolution: {integrity: sha512-qHjCGo1p9I4VJR3qfil7h0jJWTy52uNJw87MNwNEi1SYk+EaVJaqyyyoZHJmZGdn8hw3JjXvyFt/zeFZpbK/6A==}
     dependencies:
       '@types/ember': 4.0.3(@babel/core@7.21.4)
-      '@types/ember__object': 4.0.5
+      '@types/ember__object': 4.0.5(@babel/core@7.21.4)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -3362,11 +3362,30 @@ packages:
       - supports-color
     dev: true
 
+  /@types/ember__controller@4.0.4(@babel/core@7.21.4):
+    resolution: {integrity: sha512-+f0knTIJJkRX5xijeSI/n4FvLfhMFFxIxODyFFFFB483EryYuts3QzpTwU5D66WQ5rAbZvpPRXRMPTTCNJoUhg==}
+    dependencies:
+      '@types/ember__object': 4.0.5(@babel/core@7.21.4)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: true
+
   /@types/ember__debug@4.0.3:
     resolution: {integrity: sha512-LvSLFgNlzpbsdb479ohS2szCFwkAsaqPnTjyPML7xFF3r3VGFMQjVNTXQpFYQCKTMAC1FYRX1N6hw/8lpXWHKA==}
     dependencies:
       '@types/ember__object': 4.0.5
       '@types/ember__owner': 4.0.3
+    dev: true
+
+  /@types/ember__debug@4.0.3(@babel/core@7.21.4):
+    resolution: {integrity: sha512-LvSLFgNlzpbsdb479ohS2szCFwkAsaqPnTjyPML7xFF3r3VGFMQjVNTXQpFYQCKTMAC1FYRX1N6hw/8lpXWHKA==}
+    dependencies:
+      '@types/ember__object': 4.0.5(@babel/core@7.21.4)
+      '@types/ember__owner': 4.0.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
     dev: true
 
   /@types/ember__destroyable@4.0.1:
@@ -3380,6 +3399,16 @@ packages:
       '@types/ember__owner': 4.0.3
     dev: true
 
+  /@types/ember__engine@4.0.4(@babel/core@7.21.4):
+    resolution: {integrity: sha512-dxQf3ESRjTJtCHbd42/ReUpQUAUsn/VtI6+S07jrsgCbAQEr8Qkh/dJpd9Cta8N+DpbY1CUH58D4HxdOC4Ip3A==}
+    dependencies:
+      '@types/ember__object': 4.0.5(@babel/core@7.21.4)
+      '@types/ember__owner': 4.0.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: true
+
   /@types/ember__error@4.0.2:
     resolution: {integrity: sha512-0KVIvGrpyYzO4dmBm04ovJ/Fd7DjiXABxkKX42O8U01OL6O+Q+m3euQuJbB5wkYVANnvBHpcHlxRUI2y9KmzYg==}
     dev: true
@@ -3388,6 +3417,16 @@ packages:
     resolution: {integrity: sha512-gXrywWBwoW7J9y9yJqoZ0m1qtiyMdrEi29cJdF1xI2qOnMqaZeuSCMYaPQMsyq52/YnVIG2EnGzo6eUD57J4Nw==}
     dependencies:
       '@types/ember': 4.0.3
+      '@types/rsvp': 4.0.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: true
+
+  /@types/ember__object@4.0.5(@babel/core@7.21.4):
+    resolution: {integrity: sha512-gXrywWBwoW7J9y9yJqoZ0m1qtiyMdrEi29cJdF1xI2qOnMqaZeuSCMYaPQMsyq52/YnVIG2EnGzo6eUD57J4Nw==}
+    dependencies:
+      '@types/ember': 4.0.3(@babel/core@7.21.4)
       '@types/rsvp': 4.0.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -3448,6 +3487,15 @@ packages:
     resolution: {integrity: sha512-7SCTMEexxOdkpkgdyf1QLFQJhoAq6aqP6dPH9fcG8N5mTMvZGLMNIKGG9bldiq3NzHS9Pxogu3qgo5yMfc2+jA==}
     dependencies:
       '@types/ember__object': 4.0.5
+    dev: true
+
+  /@types/ember__service@4.0.2(@babel/core@7.21.4):
+    resolution: {integrity: sha512-7SCTMEexxOdkpkgdyf1QLFQJhoAq6aqP6dPH9fcG8N5mTMvZGLMNIKGG9bldiq3NzHS9Pxogu3qgo5yMfc2+jA==}
+    dependencies:
+      '@types/ember__object': 4.0.5(@babel/core@7.21.4)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
     dev: true
 
   /@types/ember__string@3.16.3:

--- a/test-app/app/components/outer.hbs
+++ b/test-app/app/components/outer.hbs
@@ -1,5 +1,9 @@
 <style>
   p { color: blue; }
+
+  p ~ .something, h1 ~ .something {
+    display: none;
+  }
 </style>
 
 <h1 data-test-outer-h1>


### PR DESCRIPTION
This adds a `encodeURIComponent`/`decodeURIComponent` step for the CSS that’s embedded in the virtual loader path. This fixes a problem with some CSS encodings that resulted in build errors, such as those seen in #11. If the base64-encoded CSS contained `+` this was decoded as a space on the other end, resulting in invalid CSS.

With this CSS:
```css
p + .something, h2 ~.x, h1 + .something {
  display: none;
}
```
This was the base64 encoding:
```
CnAgKyAuc29tZXRoaW5nLCBoMiB+LngsIGgxICsgLnNvbWV0aGluZyB7CiAgICBkaXNwbGF5OiBub25lOwogIH0K
```

In the virtual loader, that was extracted as this:
```
CnAgKyAuc29tZXRoaW5nLCBoMiB LngsIGgxICsgLnNvbWV0aGluZyB7CiAgICBkaXNwbGF5OiBub25lOwogIH0K
```

So the decoded CSS was corrupt:
```
p + .something, h2 KH
ÈÛÛY][ÈÂ\Ü^NÛNÂB
```

I have also renamed some variables that I incorrectly named based on a misunderstanding of what was actually happening. The encoding was the CSS itself, not a file reference.
