### PR TITLE
Remove Vue-specific code and document pseudo-selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,46 @@ p[data-scopedcss-53259f1da9] {
 
 Nested components only have the parent component’s styles on elements with `...attributes`. You can see this in action in `test-app`.
 
+## Additional features
+
+The implementation is adapted from a [Vue PostCSS plugin](https://github.com/vuejs/core/blob/c346af2b6aa1c2796818405b4a960fc5c571594e/packages/compiler-sfc/src/stylePluginScoped.ts). It also supports these pseudo-elements:
+
+### `:global`
+
+If you want to use CSS in your component but want a selector to not be scoped, you can use `:global`:
+
+```css
+:global(.red) {
+  color: red;
+}
+```
+
+The generated CSS will look like this:
+
+```css
+.red {
+  color: red;
+}
+```
+
+### `:deep`
+
+Using `:deep` on a selector will attach the scoping attribute to the element selector before it.
+
+```css
+.a :deep(.b) {
+  color: pink;
+}
+```
+
+The generated CSS will look like this:
+
+```css
+.a[data-scopedcss-3afb00313e] .b {
+  color: pink;
+}
+```
+
 ## :rotating_light: Limitations
 
 This is a pre-1.0 release with several limitations:

--- a/glimmer-scoped-css/src/postcss-plugin.ts
+++ b/glimmer-scoped-css/src/postcss-plugin.ts
@@ -112,34 +112,19 @@ function rewriteSelector(
   id: string,
   selector: selectorParser.Selector,
   selectorRoot: selectorParser.Root,
-  slotted = false
 ) {
   let node: selectorParser.Node | null = null
   let shouldInject = true
   // find the last child node to insert attribute selector
   selector.each(n => {
-    // DEPRECATED ">>>" and "/deep/" combinator
-    if (
-      n.type === 'combinator' &&
-      (n.value === '>>>' || n.value === '/deep/')
-    ) {
-      n.value = ' '
-      n.spaces.before = n.spaces.after = ''
-      warn(
-        `the >>> and /deep/ combinators have been deprecated. ` +
-          `Use :deep() instead.`
-      )
-      return false
-    }
-
     if (n.type === 'pseudo') {
       const { value } = n
-      // deep: inject [id] attribute at the node before the ::v-deep
+      // deep: inject [id] attribute at the node before the ::deep
       // combinator.
-      if (value === ':deep' || value === '::v-deep') {
+      if (value === ':deep') {
         if (n.nodes.length) {
-          // .foo ::v-deep(.bar) -> .foo[xxxxxxx] .bar
-          // replace the current node with ::v-deep's inner selector
+          // .foo :deep(.bar) -> .foo[xxxxxxx] .bar
+          // replace the current node with :deep's inner selector
           let last: selectorParser.Selector['nodes'][0] = n
           n.nodes[0]!.each(ss => {
             selector.insertAfter(last, ss)
@@ -156,43 +141,13 @@ function rewriteSelector(
             )
           }
           selector.removeChild(n)
-        } else {
-          // DEPRECATED usage
-          // .foo ::v-deep .bar -> .foo[xxxxxxx] .bar
-          warn(
-            `::v-deep usage as a combinator has ` +
-              `been deprecated. Use :deep(<inner-selector>) instead.`
-          )
-          const prev = selector.at(selector.index(n) - 1)
-          if (prev && isSpaceCombinator(prev)) {
-            selector.removeChild(prev)
-          }
-          selector.removeChild(n)
         }
         return false
       }
 
-      // slot: use selector inside `::v-slotted` and inject [id + '-s']
-      // instead.
-      // ::v-slotted(.foo) -> .foo[xxxxxxx-s]
-      if (value === ':slotted' || value === '::v-slotted') {
-        rewriteSelector(id, n.nodes[0]!, selectorRoot, true /* slotted */)
-        let last: selectorParser.Selector['nodes'][0] = n
-        n.nodes[0]!.each(ss => {
-          selector.insertAfter(last, ss)
-          last = ss
-        })
-        // selector.insertAfter(n, n.nodes[0])
-        selector.removeChild(n)
-        // since slotted attribute already scopes the selector there's no
-        // need for the non-slot attribute.
-        shouldInject = false
-        return false
-      }
-
       // global: replace with inner selector and do not inject [id].
-      // ::v-global(.foo) -> .foo
-      if (value === ':global' || value === '::v-global') {
+      // ::global(.foo) -> .foo
+      if (value === ':global') {
         selectorRoot.insertAfter(selector, n.nodes[0]!)
         selectorRoot.removeChild(selector)
         return false
@@ -214,14 +169,13 @@ function rewriteSelector(
   }
 
   if (shouldInject) {
-    const idToAdd = slotted ? id + '-s' : id
     selector.insertAfter(
       // If node is null it means we need to inject [id] at the start
       // insertAfter can handle `null` here
       node as any,
       selectorParser.attribute({
-        attribute: idToAdd,
-        value: idToAdd,
+        attribute: id,
+        value: id,
         raws: {},
         quoteMark: `"`
       })

--- a/glimmer-scoped-css/src/postcss-plugin.ts
+++ b/glimmer-scoped-css/src/postcss-plugin.ts
@@ -40,7 +40,7 @@ const scopedPlugin: PluginCreator<string> = (id = '') => {
   const shortId = id.replace(/^data-v-/, '')
 
   return {
-    postcssPlugin: 'vue-sfc-scoped',
+    postcssPlugin: 'glimmer-scoped-css',
     Rule(rule) {
       processRule(id, rule)
     },

--- a/test-app/app/components/inner.hbs
+++ b/test-app/app/components/inner.hbs
@@ -5,3 +5,7 @@
 <p data-test-inner-second-p>
   Inner second p.
 </p>
+
+<pre data-test-inner-pre>
+  Inner pre.
+</pre>

--- a/test-app/app/components/outer.hbs
+++ b/test-app/app/components/outer.hbs
@@ -1,8 +1,17 @@
 <style>
   p { color: blue; }
 
+  /* This exercises a bug fix related to base64 encoding of CSS */
   p ~ .something, h1 ~ .something {
     display: none;
+  }
+
+  :global(.global) {
+    color: red;
+  }
+
+  div :deep(pre) {
+    color: green;
   }
 </style>
 
@@ -12,6 +21,9 @@
 <p data-test-outer-p>
   Outer p.
 </p>
-<Inner />
+
+<div>
+  <Inner />
+</div>
 
 {{yield to="block"}}

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -8,4 +8,8 @@
   </:block>
 </Outer>
 
+<p class="global" data-test-global-p>
+  Paragraph with a class from a component style block
+</p>
+
 {{outlet}}

--- a/test-app/tests/acceptance/scoped-css-test.ts
+++ b/test-app/tests/acceptance/scoped-css-test.ts
@@ -81,4 +81,20 @@ module('Acceptance | scoped css', function (hooks) {
       color: 'rgb(0, 0, 255)',
     });
   });
+
+  test('a block can be made non-scoped with the :global pseudo-class', async function (assert) {
+    await visit('/');
+
+    assert.dom('[data-test-global-p]').hasStyle({
+      color: 'rgb(255, 0, 0)',
+    });
+  });
+
+  test('the scope attribute can be attached to the penultimate element with the :deep pseudo-class', async function (assert) {
+    await visit('/');
+
+    assert.dom('[data-test-inner-pre]').hasStyle({
+      color: 'rgb(0, 128, 0)',
+    });
+  });
 });


### PR DESCRIPTION
This renames the PostCSS plugin to `glimmer-scoped-css` and removes its Vue-specific code:
* `v-` prefixes are no longer supported on `:deep` and `:global`
* `:slotted` is removed since it doesn’t apply in Glimmer
* deprecated syntax like `>>>` and `/deep/` is removed

This also adds missing documentation and tests for `:deep` and `:global`.