### PR TITLE
Fix virtual loader name

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,6 @@ ember install glimmer-scoped-css
    +  packagerOptions: {
    +    webpackConfig: {
    +      plugins: [new GlimmerScopedCSSWebpackPlugin()],
-   +      resolveLoader: {
-   +        alias: {
-   +          'glimmer-scoped-css/virtual-loader': require.resolve(
-   +            'glimmer-scoped-css/virtual-loader'
-   +          ),
-   +        },
-   +      },
    +    },
    +  },
     });
@@ -205,7 +198,6 @@ The second part is a plugin for your current environment (by default, webpack) t
 
 ```
 Error:    6:51  error  "glimmer-scoped-css/webpack" is not found         node/no-missing-require
-Error:   51:13  error  "glimmer-scoped-css/virtual-loader" is not found  node/no-missing-require
 ```
 
 The `eslint-plugin-node` package that produces this error doesn’t understand the `exports` structure supported by newer Node versions and is unmaintained. Ember CLI has [moved](https://github.com/ember-cli/ember-cli/issues/10055) to using `eslint-plugin-n` as a drop-in replacement as of 4.10.

--- a/glimmer-scoped-css/src/webpack.ts
+++ b/glimmer-scoped-css/src/webpack.ts
@@ -3,7 +3,7 @@ import { resolve, dirname } from 'path';
 import { isScopedCSSRequest } from '.';
 
 type CB = (err: null | Error, result?: Module | undefined) => void;
-export const virtualLoaderName = 'glimmer-scoped-css';
+export const virtualLoaderName = 'glimmer-scoped-css/virtual-loader';
 
 export class GlimmerScopedCSSWebpackPlugin {
   private addLoaderAlias(compiler: Compiler, name: string, alias: string) {

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -5,13 +5,6 @@ const { GlimmerScopedCSSWebpackPlugin } = require('glimmer-scoped-css/webpack');
 
 const webpackConfig = {
   plugins: [new GlimmerScopedCSSWebpackPlugin()],
-  resolveLoader: {
-    alias: {
-      'glimmer-scoped-css/virtual-loader': require.resolve(
-        'glimmer-scoped-css/virtual-loader'
-      ),
-    },
-  },
 };
 
 module.exports = function (defaults) {


### PR DESCRIPTION
The Webpack loader is dynamically aliased in the plugin but it didn’t match the loader name embedded in the `normalModuleFactory` hook. This was masked by the loader still being manually configured in the test app’s
`ember-cli-build` file.

This also updates the documentation since the loader no longer needs to be manually specified.