### PR TITLE
Add support for unscoped attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ ember install glimmer-scoped-css
 
 ## Usage
 
-Add a top-level `<style>` element in your component `.hbs` file and it will be scoped to elements in that component only. It also works in [`<template>` in `.gjs`/`.gts` files](https://github.com/ember-template-imports/ember-template-imports). Nested `<style>` elements are not supported.
+Add a top-level `<style>` element in your component `.hbs` file and it will be scoped to elements in that component only. It also works in [`<template>` in `.gjs`/`.gts` files](https://github.com/ember-template-imports/ember-template-imports).
+
+Nested `<style>` elements cannot be processed for scoping. Use `<style unscoped>` if you need a nested element, it will not receive scoping attributes and will be passed through to output without the `unscoped` attribute.
 
 ## Architecture
 

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -50,6 +50,10 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
         let dataAttribute = `${dataAttributePrefix}-${currentTemplateStyleHash}`;
 
         if (node.tag === 'style') {
+          if (hasUnscopedAttribute(node)) {
+            return removeUnscopedAttribute(node);
+          }
+
           if (walker.parent?.node.type !== 'Template') {
             throw new Error(
               '<style> tags must be at the root of the template, they cannot be nested'
@@ -93,4 +97,19 @@ function textContent(node: ASTv1.ElementNode): string {
     (c) => c.type === 'TextNode'
   ) as ASTv1.TextNode[];
   return textChildren.map((c) => c.chars).join('');
+}
+
+const UNSCOPED_ATTRIBUTE_NAME = 'unscoped';
+
+function hasUnscopedAttribute(node: ASTv1.ElementNode): boolean {
+  return node.attributes.some(
+    (attribute) => attribute.name === UNSCOPED_ATTRIBUTE_NAME
+  );
+}
+
+function removeUnscopedAttribute(node: ASTv1.ElementNode): ASTv1.ElementNode {
+  node.attributes = node.attributes.filter(
+    (attribute) => attribute.name !== UNSCOPED_ATTRIBUTE_NAME
+  );
+  return node;
 }

--- a/test-app/app/components/outer.hbs
+++ b/test-app/app/components/outer.hbs
@@ -14,6 +14,11 @@
     color: green;
   }
 </style>
+<style data-test-unscoped-root-style unscoped>
+  p {
+    text-align: end;
+  }
+</style>
 
 <h1 data-test-outer-h1>
   Outer h1
@@ -24,6 +29,11 @@
 
 <div>
   <Inner />
+  <style unscoped>
+    p {
+      text-transform: uppercase;
+    }
+  </style>
 </div>
 
 {{yield to="block"}}

--- a/test-app/tests/acceptance/scoped-css-test.ts
+++ b/test-app/tests/acceptance/scoped-css-test.ts
@@ -92,6 +92,22 @@ module('Acceptance | scoped css', function (hooks) {
     });
   });
 
+  test('unscoped style elements are passed through without the unscoped attribute', async function (assert) {
+    await visit('/');
+
+    assert
+      .dom('[data-test-unscoped-root-style]')
+      .exists()
+      .doesNotHaveAttribute('unscoped');
+
+    assert.dom('style[unscoped]').doesNotExist();
+
+    assert.dom('[data-test-global-p]').hasStyle({
+      'text-align': 'end',
+      'text-transform': 'uppercase',
+    });
+  });
+
   test('a block can be made non-scoped with the :global pseudo-class', async function (assert) {
     await visit('/');
 


### PR DESCRIPTION
Since #21 forbids non-top-level `<style>` elements, this adds support for `<style unscoped>` elements that do not get transformed to include scoping attributes and can therefore be nested anywhere.