### PR TITLE
Add scoped class feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,42 @@ The generated CSS will look like this:
 }
 ```
 
+## Scoping with wormholes: `__GLIMMER_SCOPED_CSS_CLASS`
+
+When working with Ember Power Select or other libraries that generate elements outside of the usual component hierarchy,
+you might find the scoping doesn’t work because the dynamic elements are elsewhere in the DOM.
+
+`glimmer-scoped-css` provides an escape hatch: the placeholder `__GLIMMER_SCOPED_CSS_CLASS` will be replaced via AST
+transform so you can pass a scoping class to library components. An example with Ember Power Select:
+
+```hbs
+<PowerSelect
+  @dropdownClass='__GLIMMER_SCOPED_CSS_CLASS'
+  @options={{names}}
+  @selected={{selectedName}}
+  @labelText="Name"
+  @onChange={{fn changeName}} as |name|>
+  {{name}}
+</PowerSelect>
+```
+
+Stylesheet:
+
+```css
+.__GLIMMER_SCOPED_CSS_CLASS {
+  background-color: red;
+}
+```
+
+These will be replaced via AST transform with scoped class names, resulting in an updated `@dropdownClass`
+and a stylesheet like this:
+
+```css
+.scopedcss-f61ca3e17a-5096f06db6 {
+  background-color: red;
+}
+```
+
 ## :rotating_light: Limitations
 
 This is a pre-1.0 release with several limitations:

--- a/failing-test-app/package.json
+++ b/failing-test-app/package.json
@@ -82,7 +82,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.5.0",
     "eslint-plugin-n": "^15.7.0",
-    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-qunit": "^7.3.4",
     "glimmer-scoped-css": "^0.4.1",
     "loader.js": "^4.7.0",

--- a/glimmer-scoped-css/package.json
+++ b/glimmer-scoped-css/package.json
@@ -73,7 +73,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-ember": "^10.5.8",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
     "prettier": "^2.5.1",
     "rollup": "^2.67.0",
     "rollup-plugin-copy": "^3.4.0",

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -50,19 +50,17 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
       },
       ElementNode(node, walker) {
         let dataAttribute = `${dataAttributePrefix}-${currentTemplateStyleHash}`;
+        let scopeClass = dataAttribute.replace(/^data-/, '');
         node.attributes.forEach((attr) => {
           let val = attr.value;
           if (val.type === 'TextNode') {
             if (val.chars.includes(SCOPED_CSS_CLASS)) {
-              val.chars = val.chars.replace(SCOPED_CSS_CLASS, dataAttribute);
+              val.chars = val.chars.replace(SCOPED_CSS_CLASS, scopeClass);
             }
           } else if (val.type === 'MustacheStatement') {
             val.params.forEach((param) => {
               if (param.type === 'StringLiteral') {
-                param.value = param.value.replace(
-                  SCOPED_CSS_CLASS,
-                  dataAttribute
-                );
+                param.value = param.value.replace(SCOPED_CSS_CLASS, scopeClass);
               }
             });
           } else if (val.type === 'ConcatStatement') {

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -57,6 +57,14 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
               val.chars = val.chars.replace(SCOPED_CSS_CLASS, dataAttribute);
             }
           } else if (val.type === 'MustacheStatement') {
+            val.params.forEach((param) => {
+              if (param.type === 'StringLiteral') {
+                param.value = param.value.replace(
+                  SCOPED_CSS_CLASS,
+                  dataAttribute
+                );
+              }
+            });
           } else if (val.type === 'ConcatStatement') {
           }
         });

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -83,9 +83,9 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
           }
           let inputCSS = textContent(node);
           // replace special string with the randomly generated (hash) scoped css  class name
-          let outputCSS = postcss([scopedStylesPlugin(dataAttribute)]).process(
-            inputCSS
-          ).css;
+          let outputCSS = postcss([
+            scopedStylesPlugin([dataAttribute, SCOPED_CSS_CLASS]),
+          ]).process(inputCSS).css;
 
           // TODO: hard coding the loader chain means we ignore the other
           // prevailing rules (and we're even assuming these loaders are

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -66,6 +66,7 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
               }
             });
           } else if (val.type === 'ConcatStatement') {
+            // example: <div class="x {{@y}} z">
           }
         });
 

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -54,10 +54,12 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
         node.attributes.forEach((attr) => {
           let val = attr.value;
           if (val.type === 'TextNode') {
+            // example: <div class="x __GLIMMER_SCOPED_CSS">
             if (val.chars.includes(SCOPED_CSS_CLASS)) {
               val.chars = val.chars.replace(SCOPED_CSS_CLASS, scopeClass);
             }
           } else if (val.type === 'MustacheStatement') {
+            // example: <div class={{concat this.aClass " " "__GLIMMER_SCOPED_CSS"}}>
             val.params.forEach((param) => {
               replaceScopedClassesInAttribute(
                 param,
@@ -66,13 +68,14 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
               );
             });
           } else if (val.type === 'ConcatStatement') {
-            // example: <div class="x {{@y}} z">
             val.parts.forEach((part) => {
               if (part.type === 'TextNode') {
+                // example: <div class="x {{@y}} __GLIMMER_SCOPED_CSS">
                 if (part.chars.includes(SCOPED_CSS_CLASS)) {
                   part.chars = part.chars.replace(SCOPED_CSS_CLASS, scopeClass);
                 }
               } else if (part.type === 'MustacheStatement') {
+                // example: <div class="x {{concat this.aClass " " "__GLIMMER_SCOPED_CSS"}}">
                 part.params.forEach((param) => {
                   replaceScopedClassesInAttribute(
                     param,

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -72,10 +72,7 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
               '<style> tags must be at the root of the template, they cannot be nested'
             );
           }
-          let inputCSS = textContent(node).replace(
-            SCOPED_CSS_CLASS,
-            dataAttribute
-          );
+          let inputCSS = textContent(node);
           // replace special string with the randomly generated (hash) scoped css  class name
           let outputCSS = postcss([scopedStylesPlugin(dataAttribute)]).process(
             inputCSS

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -52,7 +52,7 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
         let dataAttribute = `${dataAttributePrefix}-${currentTemplateStyleHash}`;
 
         let scopeClass = dataAttribute.replace(/^data-/, '');
-        replaceScopedClassesInAttributes(node, scopeClass);
+        replacePlaceholderClassesInAttributes(node, scopeClass);
 
         if (node.tag === 'style') {
           if (hasUnscopedAttribute(node)) {
@@ -119,7 +119,7 @@ function removeUnscopedAttribute(node: ASTv1.ElementNode): ASTv1.ElementNode {
   return node;
 }
 
-function replaceScopedClassesInAttributes(
+function replacePlaceholderClassesInAttributes(
   elementNode: ASTv1.ElementNode,
   replacementClass: string,
 ) {
@@ -139,7 +139,7 @@ function replaceScopedClassesInAttributes(
       // example: <div class={{concat this.aClass " " "__GLIMMER_SCOPED_CSS"}}>
 
       attributeValue.params.forEach((expression) => {
-        replaceScopedClassesInExpression(
+        replacePlaceholderClassesInExpression(
           expression,
           SCOPED_CSS_CLASS,
           replacementClass,
@@ -157,7 +157,7 @@ function replaceScopedClassesInAttributes(
           // example: <div class="x {{concat this.aClass " " "__GLIMMER_SCOPED_CSS"}}">
 
           part.params.forEach((expression) => {
-            replaceScopedClassesInExpression(
+            replacePlaceholderClassesInExpression(
               expression,
               SCOPED_CSS_CLASS,
               replacementClass,
@@ -169,7 +169,7 @@ function replaceScopedClassesInAttributes(
   });
 }
 
-function replaceScopedClassesInExpression(
+function replacePlaceholderClassesInExpression(
   expression: ASTv1.Expression,
   placeholderClass: string,
   replacementClass: string,
@@ -181,7 +181,7 @@ function replaceScopedClassesInExpression(
     );
   } else if (expression.type === 'SubExpression') {
     expression.params.forEach((param) => {
-      replaceScopedClassesInExpression(
+      replacePlaceholderClassesInExpression(
         param,
         placeholderClass,
         replacementClass,

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -59,9 +59,11 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
             }
           } else if (val.type === 'MustacheStatement') {
             val.params.forEach((param) => {
-              if (param.type === 'StringLiteral') {
-                param.value = param.value.replace(SCOPED_CSS_CLASS, scopeClass);
-              }
+              replaceScopedClassesInAttribute(
+                param,
+                SCOPED_CSS_CLASS,
+                scopeClass
+              );
             });
           } else if (val.type === 'ConcatStatement') {
             // example: <div class="x {{@y}} z">
@@ -133,4 +135,25 @@ function removeUnscopedAttribute(node: ASTv1.ElementNode): ASTv1.ElementNode {
     (attribute) => attribute.name !== UNSCOPED_ATTRIBUTE_NAME
   );
   return node;
+}
+
+function replaceScopedClassesInAttribute(
+  expression: ASTv1.Expression,
+  placeholderClass: string,
+  replacementClass: string
+): void {
+  if (expression.type === 'StringLiteral') {
+    expression.value = expression.value.replace(
+      placeholderClass,
+      replacementClass
+    );
+  } else if (expression.type === 'SubExpression') {
+    expression.params.forEach((param) => {
+      replaceScopedClassesInAttribute(
+        param,
+        placeholderClass,
+        replacementClass
+      );
+    });
+  }
 }

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -89,7 +89,6 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
         });
 
         if (node.tag === 'style') {
-          //style tags
           if (hasUnscopedAttribute(node)) {
             return removeUnscopedAttribute(node);
           }
@@ -100,7 +99,6 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
             );
           }
           let inputCSS = textContent(node);
-          // replace special string with the randomly generated (hash) scoped css  class name
           let outputCSS = postcss([
             scopedStylesPlugin([dataAttribute, SCOPED_CSS_CLASS]),
           ]).process(inputCSS).css;

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -60,9 +60,9 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
             }
           } else if (val.type === 'MustacheStatement') {
             // example: <div class={{concat this.aClass " " "__GLIMMER_SCOPED_CSS"}}>
-            val.params.forEach((param) => {
-              replaceScopedClassesInAttribute(
-                param,
+            val.params.forEach((expression) => {
+              replaceScopedClassesInExpression(
+                expression,
                 SCOPED_CSS_CLASS,
                 scopeClass
               );
@@ -76,9 +76,9 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
                 }
               } else if (part.type === 'MustacheStatement') {
                 // example: <div class="x {{concat this.aClass " " "__GLIMMER_SCOPED_CSS"}}">
-                part.params.forEach((param) => {
-                  replaceScopedClassesInAttribute(
-                    param,
+                part.params.forEach((expression) => {
+                  replaceScopedClassesInExpression(
+                    expression,
                     SCOPED_CSS_CLASS,
                     scopeClass
                   );
@@ -155,7 +155,7 @@ function removeUnscopedAttribute(node: ASTv1.ElementNode): ASTv1.ElementNode {
   return node;
 }
 
-function replaceScopedClassesInAttribute(
+function replaceScopedClassesInExpression(
   expression: ASTv1.Expression,
   placeholderClass: string,
   replacementClass: string
@@ -167,7 +167,7 @@ function replaceScopedClassesInAttribute(
     );
   } else if (expression.type === 'SubExpression') {
     expression.params.forEach((param) => {
-      replaceScopedClassesInAttribute(
+      replaceScopedClassesInExpression(
         param,
         placeholderClass,
         replacementClass

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -67,6 +67,21 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
             });
           } else if (val.type === 'ConcatStatement') {
             // example: <div class="x {{@y}} z">
+            val.parts.forEach((part) => {
+              if (part.type === 'TextNode') {
+                if (part.chars.includes(SCOPED_CSS_CLASS)) {
+                  part.chars = part.chars.replace(SCOPED_CSS_CLASS, scopeClass);
+                }
+              } else if (part.type === 'MustacheStatement') {
+                part.params.forEach((param) => {
+                  replaceScopedClassesInAttribute(
+                    param,
+                    SCOPED_CSS_CLASS,
+                    scopeClass
+                  );
+                });
+              }
+            });
           }
         });
 

--- a/glimmer-scoped-css/src/postcss-plugin.ts
+++ b/glimmer-scoped-css/src/postcss-plugin.ts
@@ -35,18 +35,17 @@ function warn(message: string){
   console.warn(message);
 }
 
-// FIXME can this be parameterised?
-const SCOPED_CSS_CLASS = '__GLIMMER_SCOPED_CSS_CLASS';
-
-const scopedPlugin: PluginCreator<string> = (id = '') => {
+const scopedPlugin: PluginCreator<[string, string]> = (
+  [id = '', scopeClass = ''] = ['', '']
+) => {
   const keyframes = Object.create(null)
   const shortId = id.replace(/^data-v-/, '')
 
   return {
     postcssPlugin: 'glimmer-scoped-css',
     Rule(rule) {
-      if (rule.selector.includes(SCOPED_CSS_CLASS)) {
-        rule.selector = rule.selector.replace(SCOPED_CSS_CLASS, id);
+      if (rule.selector.includes(scopeClass)) {
+        rule.selector = rule.selector.replace(scopeClass, id);
         return;
       } else if (rule.selector.includes(id)) {
         // The above change will result in this rule being processed again, let’s skip

--- a/glimmer-scoped-css/src/postcss-plugin.ts
+++ b/glimmer-scoped-css/src/postcss-plugin.ts
@@ -36,18 +36,19 @@ function warn(message: string){
 }
 
 const scopedPlugin: PluginCreator<[string, string]> = (
-  [id = '', scopeClass = ''] = ['', '']
+  [id = '', classToReplace = ''] = ['', '']
 ) => {
   const keyframes = Object.create(null)
   const shortId = id.replace(/^data-v-/, '')
+  const replacementClass = id.replace(/^data-/, '');
 
   return {
     postcssPlugin: 'glimmer-scoped-css',
     Rule(rule) {
-      if (rule.selector.includes(scopeClass)) {
-        rule.selector = rule.selector.replace(scopeClass, id);
+      if (rule.selector.includes(classToReplace)) {
+        rule.selector = rule.selector.replace(classToReplace, replacementClass);
         return;
-      } else if (rule.selector.includes(id)) {
+      } else if (rule.selector.includes(replacementClass)) {
         // The above change will result in this rule being processed again, let’s skip
         return;
       } else {

--- a/glimmer-scoped-css/src/postcss-plugin.ts
+++ b/glimmer-scoped-css/src/postcss-plugin.ts
@@ -35,6 +35,9 @@ function warn(message: string){
   console.warn(message);
 }
 
+// FIXME can this be parameterised?
+const SCOPED_CSS_CLASS = '__GLIMMER_SCOPED_CSS_CLASS';
+
 const scopedPlugin: PluginCreator<string> = (id = '') => {
   const keyframes = Object.create(null)
   const shortId = id.replace(/^data-v-/, '')
@@ -42,7 +45,15 @@ const scopedPlugin: PluginCreator<string> = (id = '') => {
   return {
     postcssPlugin: 'glimmer-scoped-css',
     Rule(rule) {
-      processRule(id, rule)
+      if (rule.selector.includes(SCOPED_CSS_CLASS)) {
+        rule.selector = rule.selector.replace(SCOPED_CSS_CLASS, id);
+        return;
+      } else if (rule.selector.includes(id)) {
+        // The above change will result in this rule being processed again, let’s skip
+        return;
+      } else {
+        processRule(id, rule);
+      }
     },
     AtRule(node) {
       if (

--- a/glimmer-scoped-css/src/virtual-loader.ts
+++ b/glimmer-scoped-css/src/virtual-loader.ts
@@ -7,7 +7,7 @@ export default function virtualLoader(this: LoaderContext<unknown>) {
 
   if (typeof optionsString !== 'string') {
     throw new Error(
-      `glimmer-scoped-css/src/virtual-loader received unexpected request: ${optionsString}`
+      `glimmer-scoped-css/src/virtual-loader received unexpected request: ${optionsString}`,
     );
   }
 
@@ -17,7 +17,7 @@ export default function virtualLoader(this: LoaderContext<unknown>) {
 
   if (!filename) {
     throw new Error(
-      `glimmer-scoped-css/src/virtual-loader missing filename parameter: ${optionsString}`
+      `glimmer-scoped-css/src/virtual-loader missing filename parameter: ${optionsString}`,
     );
   }
 

--- a/glimmer-scoped-css/src/webpack.ts
+++ b/glimmer-scoped-css/src/webpack.ts
@@ -24,7 +24,7 @@ export class GlimmerScopedCSSWebpackPlugin {
     this.addLoaderAlias(
       compiler,
       virtualLoaderName,
-      resolve(__dirname, './virtual-loader')
+      resolve(__dirname, './virtual-loader'),
     );
 
     compiler.hooks.normalModuleFactory.tap('glimmer-scoped-css', (nmf) => {
@@ -50,12 +50,12 @@ export class GlimmerScopedCSSWebpackPlugin {
             ) {
               state.request = `style-loader!css-loader!glimmer-scoped-css/virtual-loader?filename=${resolve(
                 dirname(state.contextInfo.issuer),
-                state.request
+                state.request,
               )}!`;
             }
           }
           callback(null, undefined);
-        }
+        },
       );
     });
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
     "prettier": "^2.5.1",
     "release-it": "^15.5.0"
   },
+  "pnpm": {
+    "overrides": {
+      "prettier": "github:cardstack/prettier#glimmer-style-tag-in-template-support"
+    }
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
+
 importers:
 
   .:
@@ -18,8 +21,8 @@ importers:
         specifier: ^7.2.1
         version: 7.6.0
       prettier:
-        specifier: ^2.5.1
-        version: 2.8.8
+        specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
+        version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       release-it:
         specifier: ^15.5.0
         version: 15.11.0
@@ -208,7 +211,7 @@ importers:
         version: 15.7.0(eslint@8.42.0)
       eslint-plugin-prettier:
         specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@2.8.8)
+        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@3.1.0-dev)
       eslint-plugin-qunit:
         specifier: ^7.3.4
         version: 7.3.4(eslint@8.42.0)
@@ -219,8 +222,8 @@ importers:
         specifier: ^4.7.0
         version: 4.7.0
       prettier:
-        specifier: ^2.8.7
-        version: 2.8.8
+        specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
+        version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       qunit:
         specifier: ^2.19.4
         version: 2.19.4
@@ -392,10 +395,10 @@ importers:
         version: 11.1.0(eslint@7.32.0)
       eslint-plugin-prettier:
         specifier: ^4.0.0
-        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@7.32.0)(prettier@2.8.8)
+        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@7.32.0)(prettier@3.1.0-dev)
       prettier:
-        specifier: ^2.5.1
-        version: 2.8.8
+        specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
+        version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       rollup:
         specifier: ^2.67.0
         version: 2.79.1
@@ -602,7 +605,7 @@ importers:
         version: 15.7.0(eslint@8.42.0)
       eslint-plugin-prettier:
         specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@2.8.8)
+        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@3.1.0-dev)
       eslint-plugin-qunit:
         specifier: ^7.3.4
         version: 7.3.4(eslint@8.42.0)
@@ -613,11 +616,11 @@ importers:
         specifier: ^4.7.0
         version: 4.7.0
       prettier:
-        specifier: ^2.8.7
-        version: 2.8.8
+        specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
+        version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       prettier-plugin-ember-template-tag:
         specifier: ^1.0.2
-        version: 1.0.2(prettier@2.8.8)
+        version: 1.0.2(prettier@3.1.0-dev)
       qunit:
         specifier: ^2.19.4
         version: 2.19.4
@@ -644,6 +647,18 @@ packages:
       '@jridgewell/trace-mapping': 0.3.18
     dev: true
 
+  /@angular/compiler@16.1.4:
+    resolution: {integrity: sha512-5iKx8g+6/LtiRhbqMS2Jw1AshFUb4M8LO9WQKfRoE+5mZrDOYkAQYgOlAO7fk0mOCXeZcHJBbq2nuwDfwsZIiw==}
+    engines: {node: ^16.14.0 || >=18.10.0}
+    peerDependencies:
+      '@angular/core': 16.1.4
+    peerDependenciesMeta:
+      '@angular/core':
+        optional: true
+    dependencies:
+      tslib: 2.5.3
+    dev: true
+
   /@babel/code-frame@7.12.11:
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
     dependencies:
@@ -662,7 +677,7 @@ packages:
     resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.22.5
+      '@babel/highlight': 7.22.10
     dev: true
 
   /@babel/compat-data@7.22.5:
@@ -735,7 +750,7 @@ packages:
     resolution: {integrity: sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
@@ -745,14 +760,14 @@ packages:
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-builder-binary-assignment-operator-visitor@7.22.5:
     resolution: {integrity: sha512-m1EP3lVOPptR+2DwD125gziZNcmoNSHGmJROKoy87loWUQyJaVXDgpmruWqDARZSmtYQ+Dl25okU8+qhVzuykw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-compilation-targets@7.22.10:
@@ -777,7 +792,7 @@ packages:
       '@babel/helper-validator-option': 7.22.5
       browserslist: 4.21.7
       lru-cache: 5.1.1
-      semver: 6.3.0
+      semver: 6.3.1
     dev: true
 
   /@babel/helper-compilation-targets@7.22.5(@babel/core@7.22.5):
@@ -900,28 +915,28 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-member-expression-to-functions@7.22.5:
     resolution: {integrity: sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-module-imports@7.22.5:
     resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-module-transforms@7.22.5:
@@ -935,7 +950,7 @@ packages:
       '@babel/helper-validator-identifier': 7.22.5
       '@babel/template': 7.22.5
       '@babel/traverse': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -958,7 +973,7 @@ packages:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-plugin-utils@7.22.5:
@@ -991,7 +1006,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-wrap-function': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1005,7 +1020,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.22.5
       '@babel/template': 7.22.5
       '@babel/traverse': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1014,21 +1029,21 @@ packages:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-split-export-declaration@7.22.5:
     resolution: {integrity: sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-split-export-declaration@7.22.6:
@@ -1060,7 +1075,7 @@ packages:
       '@babel/helper-function-name': 7.22.5
       '@babel/template': 7.22.5
       '@babel/traverse': 7.22.10(supports-color@8.1.1)
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1082,7 +1097,7 @@ packages:
     dependencies:
       '@babel/template': 7.22.5
       '@babel/traverse': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1118,7 +1133,15 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
+    dev: true
+
+  /@babel/parser@7.22.7:
+    resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.22.10):
@@ -3073,7 +3096,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.22.10)
       '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.22.10)
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
       esutils: 2.0.3
     dev: true
 
@@ -3086,7 +3109,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.22.5)
       '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.22.5)
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
       esutils: 2.0.3
     dev: true
 
@@ -3127,9 +3150,9 @@ packages:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.5
-      '@babel/parser': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/code-frame': 7.22.10
+      '@babel/parser': 7.22.10
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/traverse@7.22.10(supports-color@8.1.1):
@@ -3154,14 +3177,14 @@ packages:
     resolution: {integrity: sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.22.10
       '@babel/generator': 7.22.5
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.5
-      '@babel/parser': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/parser': 7.22.10
+      '@babel/types': 7.22.10
       debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
@@ -4492,6 +4515,14 @@ packages:
       config-chain: 1.1.13
     dev: true
 
+  /@prettier/is-es5-identifier-name@0.2.0:
+    resolution: {integrity: sha512-m+8UrOLJPSTOgzgIskZXA7nxxQE/2FtPeBDRlZhWgje+Ug9UTVdJZ56l/A2GlZM/6weuJ+Tb/EJshC8Ns3Ji8w==}
+    dev: true
+
+  /@prettier/parse-srcset@3.0.0:
+    resolution: {integrity: sha512-RLDllPrker3fNbSnaYPbhRFuxA0g1tzqSkWmoCCWFI52EChqhY38UrySG2p7+METrhkxAVuQW6sVYELX7zT7Yg==}
+    dev: true
+
   /@release-it-plugins/lerna-changelog@5.0.0(release-it@15.11.0):
     resolution: {integrity: sha512-nMhAUptKSfIsiY0c//HuBcd2VT7D/IoxAQNwRgPx+jf3FM7HA5KD4KSl3oLoz4uA4GjvypWQP4ODX8UbWjmUZA==}
     engines: {node: ^14.13.1 || >= 16}
@@ -4756,14 +4787,14 @@ packages:
   /@types/babel__generator@7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/parser': 7.22.10
+      '@babel/types': 7.22.10
     dev: true
 
   /@types/babel__traverse@7.20.1:
@@ -5527,6 +5558,11 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@typescript-eslint/types@5.61.0:
+    resolution: {integrity: sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
   /@typescript-eslint/typescript-estree@5.59.9(typescript@4.9.5):
     resolution: {integrity: sha512-pmM0/VQ7kUhd1QyIxgS+aRvMgw+ZljB3eDb+jYyp6d2bC0mQWLzUDF+DLwCTkQ3tlNyVsvZRXjFyV0LkU/aXjA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5544,6 +5580,27 @@ packages:
       semver: 7.5.1
       tsutils: 3.21.0(typescript@4.9.5)
       typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree@5.61.0(typescript@5.1.6):
+    resolution: {integrity: sha512-Fud90PxONnnLZ36oR5ClJBLTLfU4pIWBmnvGwTbEa2cXIqj70AEDEmOmpkFComjBZ/037ueKrOdHuYmSFVD7Rw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.61.0
+      '@typescript-eslint/visitor-keys': 5.61.0
+      debug: 4.3.4(supports-color@8.1.1)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.1
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5593,6 +5650,14 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.59.9
+      eslint-visitor-keys: 3.4.1
+    dev: true
+
+  /@typescript-eslint/visitor-keys@5.61.0:
+    resolution: {integrity: sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.61.0
       eslint-visitor-keys: 3.4.1
     dev: true
 
@@ -5770,6 +5835,14 @@ packages:
       acorn: 7.4.1
     dev: true
 
+  /acorn-jsx@5.3.2(acorn@8.10.0):
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.10.0
+    dev: true
+
   /acorn-jsx@5.3.2(acorn@8.8.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -5796,6 +5869,12 @@ packages:
 
   /acorn@7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /acorn@8.10.0:
+    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -5900,6 +5979,24 @@ packages:
   /amdefine@1.0.1:
     resolution: {integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==}
     engines: {node: '>=0.4.2'}
+    dev: true
+
+  /angular-estree-parser@7.0.0(@angular/compiler@16.1.4):
+    resolution: {integrity: sha512-aQxqB9sCwh2S2pu/gyLBubkMTGCOLs0C/54zrUqUOjcydyBqeQrZP+m/8otCCQvmoKEpR75A14CNFuupk1zFlQ==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      '@angular/compiler': ^16.0.0
+    dependencies:
+      '@angular/compiler': 16.1.4
+      lines-and-columns: 2.0.3
+      tslib: 2.5.3
+    dev: true
+
+  /angular-html-parser@4.0.1:
+    resolution: {integrity: sha512-x9SLf2jNNh3nG+haVIwKX/GVW8PcvSRmkeT9WqTDYSAVuwT9IzwEyVm09FCZpOo/dtFRxE9vaNXqcAf/MIxphg==}
+    engines: {node: '>= 14'}
+    dependencies:
+      tslib: 2.5.3
     dev: true
 
   /ansi-align@3.0.1:
@@ -6433,7 +6530,7 @@ packages:
     resolution: {integrity: sha512-jDLlxI8QnfKd7PtieH6pl4tZJzymzfCDCPGdTq/grgbiYAikwDPp/oL0IlFJn0HQjLpcLkyYhPKkUVneRESw5w==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
       lodash: 4.17.21
     dev: true
 
@@ -6869,6 +6966,10 @@ packages:
     resolution: {integrity: sha512-ADy1ztN074YkWbHi8ojJVFe3vAanO/lrzMGZWUClIP7oDD/Pjy2vrASraUP+2EVCfIiTtCW4FChVow01XneivA==}
     dependencies:
       underscore: 1.13.6
+    dev: true
+
+  /bail@1.0.5:
+    resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==}
     dev: true
 
   /balanced-match@1.0.2:
@@ -7812,6 +7913,10 @@ packages:
       redeyed: 1.0.1
     dev: true
 
+  /ccount@1.1.0:
+    resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
+    dev: true
+
   /chalk@1.1.3:
     resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
     engines: {node: '>=0.10.0'}
@@ -7845,8 +7950,25 @@ packages:
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
 
+  /chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: true
+
+  /character-entities-legacy@1.1.4:
+    resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
+    dev: true
+
+  /character-entities@1.2.4:
+    resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
+    dev: true
+
   /character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+    dev: true
+
+  /character-reference-invalid@1.1.4:
+    resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
     dev: true
 
   /chardet@0.7.0:
@@ -7872,6 +7994,14 @@ packages:
   /ci-info@3.8.0:
     resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
     engines: {node: '>=8'}
+    dev: true
+
+  /cjk-regex@3.0.0:
+    resolution: {integrity: sha512-2TAs+OPSJUPwNa2aI5vyo2ZHh3/0i+BKv0iwRdmTMF8SvI+aK6hdQTO5UnCGFyuUkf/upNsrH3kibbhPLzbg6w==}
+    engines: {node: '>=16'}
+    dependencies:
+      regexp-util: 2.0.0
+      unicode-regex: 4.0.0
     dev: true
 
   /class-utils@0.3.6:
@@ -8019,6 +8149,10 @@ packages:
   /clone@2.1.2:
     resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
     engines: {node: '>=0.8'}
+    dev: true
+
+  /collapse-white-space@1.0.6:
+    resolution: {integrity: sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==}
     dev: true
 
   /collection-visit@1.0.0:
@@ -8496,6 +8630,16 @@ packages:
       path-type: 4.0.0
     dev: true
 
+  /cosmiconfig@8.2.0:
+    resolution: {integrity: sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    dev: true
+
   /cross-spawn@6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
     engines: {node: '>=4.8'}
@@ -8570,6 +8714,10 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
+  /css-units-list@2.0.1:
+    resolution: {integrity: sha512-dzkuF54ip2CmGWXgQAvDohyNKPOjd7mQPQoAwFmqCjaHsOcmkMG6oiKi2+mexnuWU0pl5oJ+7+2aUKFEGNAQmw==}
+    dev: true
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -8599,6 +8747,11 @@ packages:
 
   /dag-map@2.0.2:
     resolution: {integrity: sha512-xnsprIzYuDeiyu5zSKwilV/ajRHxnoMlAhEREfyfTgTSViMVY2fGP1ZcHJbtwup26oCkofySU/m6oKJ3HrkW7w==}
+    dev: true
+
+  /dashify@2.0.0:
+    resolution: {integrity: sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==}
+    engines: {node: '>=4'}
     dev: true
 
   /data-uri-to-buffer@4.0.1:
@@ -8914,6 +9067,20 @@ packages:
       semver: 6.3.1
     dev: true
 
+  /editorconfig-to-prettier@1.0.0:
+    resolution: {integrity: sha512-WkBQRWxQOat9zBBhrnV0eoCRRMj0fMc/OIwTs+R3pvjsBD2fhTjGLLToGwalUwug3L5K4NvTTMfVRRHT6Hmorg==}
+    dev: true
+
+  /editorconfig@0.15.3:
+    resolution: {integrity: sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==}
+    hasBin: true
+    dependencies:
+      commander: 2.20.3
+      lru-cache: 4.1.5
+      semver: 5.7.1
+      sigmund: 1.0.1
+    dev: true
+
   /ee-first@1.1.1:
     resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: true
@@ -9166,6 +9333,7 @@ packages:
       chalk: 4.1.2
       remove-types: 1.0.0
     transitivePeerDependencies:
+      - '@angular/core'
       - supports-color
     dev: true
 
@@ -9395,6 +9563,7 @@ packages:
       workerpool: 6.4.0
       yam: 1.0.0
     transitivePeerDependencies:
+      - '@angular/core'
       - arc-templates
       - atpl
       - babel-core
@@ -9658,6 +9827,7 @@ packages:
       semver: 7.5.1
       silent-error: 1.1.1
     transitivePeerDependencies:
+      - '@angular/core'
       - '@babel/core'
       - '@glint/template'
       - supports-color
@@ -9732,6 +9902,10 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: true
+
+  /emoji-regex@10.2.1:
+    resolution: {integrity: sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==}
     dev: true
 
   /emoji-regex@8.0.0:
@@ -10130,37 +10304,37 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@7.32.0)(prettier@2.8.8):
+  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@7.32.0)(prettier@3.1.0-dev):
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       eslint: '>=7.28.0'
       eslint-config-prettier: '*'
-      prettier: '>=2.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       eslint-config-prettier:
         optional: true
     dependencies:
       eslint: 7.32.0
       eslint-config-prettier: 8.8.0(eslint@7.32.0)
-      prettier: 2.8.8
+      prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       prettier-linter-helpers: 1.0.0
     dev: true
 
-  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@2.8.8):
+  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@3.1.0-dev):
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       eslint: '>=7.28.0'
       eslint-config-prettier: '*'
-      prettier: '>=2.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       eslint-config-prettier:
         optional: true
     dependencies:
       eslint: 8.42.0
       eslint-config-prettier: 8.8.0(eslint@8.42.0)
-      prettier: 2.8.8
+      prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       prettier-linter-helpers: 1.0.0
     dev: true
 
@@ -10349,6 +10523,15 @@ packages:
     dependencies:
       acorn: 8.8.2
       acorn-jsx: 5.3.2(acorn@8.8.2)
+      eslint-visitor-keys: 3.4.1
+    dev: true
+
+  /espree@9.6.0:
+    resolution: {integrity: sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      acorn: 8.10.0
+      acorn-jsx: 5.3.2(acorn@8.10.0)
       eslint-visitor-keys: 3.4.1
     dev: true
 
@@ -10575,6 +10758,10 @@ packages:
     dependencies:
       assign-symbols: 1.0.0
       is-extendable: 1.0.1
+    dev: true
+
+  /extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
     dev: true
 
   /external-editor@3.1.0:
@@ -10814,6 +11001,10 @@ packages:
     resolution: {integrity: sha512-XYKutXMrIK99YMUPf91KX5QVJoG31/OsgftD6YoTPAObfQIxM4ziA9f0J1AsqKhJmo+IeaIPP0CFopTD4bdUBw==}
     dev: true
 
+  /find-parent-dir@0.3.1:
+    resolution: {integrity: sha512-o4UcykWV/XN9wm+jMEtWLPlV8RXCZnMhQI6F6OdHeSez7iiJWePw8ijOlskJZMsaQoGR/b7dH6lO02HhaTN7+A==}
+    dev: true
+
   /find-up@2.1.0:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
     engines: {node: '>=4'}
@@ -10936,6 +11127,16 @@ packages:
 
   /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
+    dev: true
+
+  /flatten@1.0.3:
+    resolution: {integrity: sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==}
+    deprecated: flatten is deprecated in favor of utility frameworks such as lodash.
+    dev: true
+
+  /flow-parser@0.211.1:
+    resolution: {integrity: sha512-TjUjPTe22yM1DYKDqsmnUblJ0Vs5WJWP3FeaXU8L1gGKGrAQBdxRvs0CRj6NXYF8gugej4JyRWGBbaiVunC9uw==}
+    engines: {node: '>=0.4.0'}
     dev: true
 
   /follow-redirects@1.15.2:
@@ -11189,6 +11390,11 @@ packages:
   /get-stdin@4.0.1:
     resolution: {integrity: sha512-F5aQMywwJ2n85s4hJPTT9RPxGmubonuB10MNYo17/xph174n2MIR33HRguhzVag10O/npM7SPk73LMZNP+FaWw==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /get-stdin@9.0.0:
+    resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
+    engines: {node: '>=12'}
     dev: true
 
   /get-stream@4.1.0:
@@ -11491,6 +11697,11 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
+  /graphql@16.7.1:
+    resolution: {integrity: sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: true
+
   /growly@1.3.0:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}
     dev: true
@@ -11653,6 +11864,16 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
+  /hermes-estree@0.14.0:
+    resolution: {integrity: sha512-L6M67+0/eSEbt6Ha2XOBFXL++7MR34EOJMgm+j7YCaI4L/jZqrVAg6zYQKzbs1ZCFDLvEQpOgLlapTX4gpFriA==}
+    dev: true
+
+  /hermes-parser@0.14.0:
+    resolution: {integrity: sha512-pt+8uRiJhVlErY3fiXB3gKhZ72RxM6E1xRMpvfZ5n6Z5TQKQQXKorgRCRzoe02mmvLKBJFP5nPDGv75MWAgCTw==}
+    dependencies:
+      hermes-estree: 0.14.0
+    dev: true
+
   /highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
     dev: true
@@ -11678,6 +11899,10 @@ packages:
       lru-cache: 7.18.3
     dev: true
 
+  /html-element-attributes@3.2.0:
+    resolution: {integrity: sha512-wdtYaghl6M4N4Bp91QE9p1AS849PHoa1tPrkSmEhxgF4VnD04o5BrEaODc1XqPjjt5UmuzOJNn0hvoWu0514nQ==}
+    dev: true
+
   /html-encoding-sniffer@2.0.1:
     resolution: {integrity: sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==}
     engines: {node: '>=10'}
@@ -11687,6 +11912,14 @@ packages:
 
   /html-entities@2.3.5:
     resolution: {integrity: sha512-72TJlcMkYsEJASa/3HnX7VT59htM7iSHbH59NSZbtc+22Ap0Txnlx91sfeB+/A7wNZg7UxtZdhAW4y+/jimrdg==}
+    dev: true
+
+  /html-styles@1.0.0:
+    resolution: {integrity: sha512-cDl5dcj73oI4Hy0DSUNh54CAwslNLJRCCoO+RNkVo+sBrjA/0+7E/xzvj3zH/GxbbBLGJhE0hBe1eg+0FINC6w==}
+    dev: true
+
+  /html-tag-names@2.1.0:
+    resolution: {integrity: sha512-+NhBUNvS5Ig8g8LO1DBpyapuGsu+FLcpLwmMADCntvU9IUa30++WV3GmuBHZm8Y9cHdIson/uvbQ/6jVL63XZw==}
     dev: true
 
   /http-cache-semantics@4.1.1:
@@ -11855,6 +12088,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /import-meta-resolve@3.0.0:
+    resolution: {integrity: sha512-4IwhLhNNA8yy445rPjD/lWh++7hMDOml2eHtd58eG7h+qK3EryMuuRbsHGPikCoAgIkkDnckKfWSk2iDla/ejg==}
+    dev: true
+
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -11863,6 +12100,10 @@ packages:
   /indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+    dev: true
+
+  /indexes-of@1.0.1:
+    resolution: {integrity: sha512-bup+4tap3Hympa+JBJUG7XuOsdNQ6fxt0MHyXMKuLBKn0OqsTfvUxkUrroEX1+B2VsSHvCjiIcZVxRtYa4nllA==}
     dev: true
 
   /infer-owner@1.0.4:
@@ -12044,6 +12285,17 @@ packages:
       kind-of: 6.0.3
     dev: true
 
+  /is-alphabetical@1.0.4:
+    resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
+    dev: true
+
+  /is-alphanumerical@1.0.4:
+    resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
+    dependencies:
+      is-alphabetical: 1.0.4
+      is-decimal: 1.0.4
+    dev: true
+
   /is-arguments@1.1.1:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
     engines: {node: '>= 0.4'}
@@ -12080,6 +12332,11 @@ packages:
 
   /is-buffer@1.1.6:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+    dev: true
+
+  /is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
     dev: true
 
   /is-callable@1.2.7:
@@ -12119,6 +12376,10 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
+    dev: true
+
+  /is-decimal@1.0.4:
+    resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
     dev: true
 
   /is-descriptor@0.1.6:
@@ -12188,6 +12449,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
+    dev: true
+
+  /is-hexadecimal@1.0.4:
+    resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
     dev: true
 
   /is-inside-container@1.0.0:
@@ -12396,9 +12661,17 @@ packages:
       call-bind: 1.0.2
     dev: true
 
+  /is-whitespace-character@1.0.4:
+    resolution: {integrity: sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==}
+    dev: true
+
   /is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-word-character@1.0.4:
+    resolution: {integrity: sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==}
     dev: true
 
   /is-wsl@2.2.0:
@@ -12489,6 +12762,13 @@ packages:
     dependencies:
       es-get-iterator: 1.1.3
       iterate-iterator: 1.0.2
+    dev: true
+
+  /jest-docblock@29.4.3:
+    resolution: {integrity: sha512-fzdTftThczeSD9nZ3fzA/4KkHtnmllawWrXO69vtI+L9WjEIuXWs4AmyME7lN5hU7dB0sHhuPfcKofRsUb/2Fg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      detect-newline: 3.1.0
     dev: true
 
   /jest-worker@27.5.1:
@@ -12735,6 +13015,16 @@ packages:
       - supports-color
     dev: true
 
+  /leven@2.1.0:
+    resolution: {integrity: sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /leven@4.0.0:
+    resolution: {integrity: sha512-puehA3YKku3osqPlNuzGDUHq8WpwXupUg1V6NXdV38G+gr+gkBwFC8g1b/+YcIvp8gnqVIus+eJCH/eGsRmJNw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
   /levn@0.3.0:
     resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
     engines: {node: '>= 0.8.0'}
@@ -12760,6 +13050,15 @@ packages:
 
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    dev: true
+
+  /lines-and-columns@2.0.3:
+    resolution: {integrity: sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
+  /linguist-languages@7.21.0:
+    resolution: {integrity: sha512-KrWJJbFOvlDhjlt5OhUipVlXg+plUfRurICAyij1ZVxQcqPt/zeReb9KiUVdGUwwhS/2KS9h3TbyfYLA5MDlxQ==}
     dev: true
 
   /linkify-it@4.0.1:
@@ -13057,6 +13356,13 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
+  /lru-cache@4.1.5:
+    resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
+    dependencies:
+      pseudomap: 1.0.2
+      yallist: 2.1.2
+    dev: true
+
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
@@ -13162,6 +13468,10 @@ packages:
       object-visit: 1.0.1
     dev: true
 
+  /markdown-escapes@1.0.4:
+    resolution: {integrity: sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==}
+    dev: true
+
   /markdown-it-terminal@0.4.0(markdown-it@13.0.1):
     resolution: {integrity: sha512-NeXtgpIK6jBciHTm9UhiPnyHDdqyVIdRPJ+KdQtZaf/wR74gvhCNbw5li4TYsxRp5u3ZoHEF4DwpECeZqyCw+w==}
     peerDependencies:
@@ -13249,6 +13559,14 @@ packages:
       p-is-promise: 2.1.0
     dev: true
 
+  /mem@9.0.2:
+    resolution: {integrity: sha512-F2t4YIv9XQUBHt6AOJ0y7lSmP1+cY7Fm1DRh9GClTGzKST7UWLMx6ly9WZdLH/G/ppM5RL4MlQfRT71ri9t19A==}
+    engines: {node: '>=12.20'}
+    dependencies:
+      map-age-cleaner: 0.1.3
+      mimic-fn: 4.0.0
+    dev: true
+
   /memory-streams@0.1.3:
     resolution: {integrity: sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==}
     dependencies:
@@ -13275,6 +13593,11 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+    dev: true
+
+  /meriyah@4.3.7:
+    resolution: {integrity: sha512-JAlSOUqFU/rmLy2CEdZO5hN5E5dyUj1f4AlRR4GCQMjfobvd5lcm9JLkrqq0MgVaLQ/Zur590A+0RyUZhj0b5A==}
+    engines: {node: '>=10.4.0'}
     dev: true
 
   /methods@1.1.2:
@@ -13720,6 +14043,11 @@ packages:
       thenify-all: 1.6.0
     dev: true
 
+  /n-readlines@1.0.1:
+    resolution: {integrity: sha512-z4SyAIVgMy7CkgsoNw7YVz40v0g4+WWvvqy8+ZdHrCtgevcEO758WQyrYcw3XPxcLxF+//RszTz/rO48nzD0wQ==}
+    engines: {node: '>=6.x.x'}
+    dev: true
+
   /nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -14134,6 +14462,10 @@ packages:
       os-tmpdir: 1.0.2
     dev: true
 
+  /outdent@0.8.0:
+    resolution: {integrity: sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==}
+    dev: true
+
   /p-cancelable@1.1.0:
     resolution: {integrity: sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==}
     engines: {node: '>=6'}
@@ -14307,11 +14639,22 @@ packages:
       callsites: 3.1.0
     dev: true
 
+  /parse-entities@2.0.0:
+    resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
+    dependencies:
+      character-entities: 1.2.4
+      character-entities-legacy: 1.1.4
+      character-reference-invalid: 1.1.4
+      is-alphanumerical: 1.0.4
+      is-decimal: 1.0.4
+      is-hexadecimal: 1.0.4
+    dev: true
+
   /parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.22.10
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -14475,6 +14818,12 @@ packages:
       find-up: 3.0.0
     dev: true
 
+  /please-upgrade-node@3.2.0:
+    resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
+    dependencies:
+      semver-compare: 1.0.0
+    dev: true
+
   /portfinder@1.0.32:
     resolution: {integrity: sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==}
     engines: {node: '>= 0.12.0'}
@@ -14489,6 +14838,19 @@ packages:
   /posix-character-classes@0.1.1:
     resolution: {integrity: sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /postcss-less@6.0.0(postcss@8.4.25):
+    resolution: {integrity: sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      postcss: ^8.3.5
+    dependencies:
+      postcss: 8.4.25
+    dev: true
+
+  /postcss-media-query-parser@0.2.3:
+    resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
     dev: true
 
   /postcss-modules-extract-imports@3.0.0(postcss@8.4.24):
@@ -14532,6 +14894,23 @@ packages:
       postcss: 8.4.24
     dev: true
 
+  /postcss-scss@4.0.6(postcss@8.4.25):
+    resolution: {integrity: sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.4.19
+    dependencies:
+      postcss: 8.4.25
+    dev: true
+
+  /postcss-selector-parser@2.2.3:
+    resolution: {integrity: sha512-3pqyakeGhrO0BQ5+/tGTfvi5IAUAhHRayGK8WFSu06aEv2BmHoXw/Mhb+w7VY5HERIuC+QoUI7wgrCcq2hqCVA==}
+    dependencies:
+      flatten: 1.0.3
+      indexes-of: 1.0.1
+      uniq: 1.0.1
+    dev: true
+
   /postcss-selector-parser@6.0.13:
     resolution: {integrity: sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==}
     engines: {node: '>=4'}
@@ -14543,6 +14922,15 @@ packages:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: true
 
+  /postcss-values-parser@2.0.1:
+    resolution: {integrity: sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==}
+    engines: {node: '>=6.14.4'}
+    dependencies:
+      flatten: 1.0.3
+      indexes-of: 1.0.1
+      uniq: 1.0.1
+    dev: true
+
   /postcss@8.4.24:
     resolution: {integrity: sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -14550,6 +14938,15 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
+
+  /postcss@8.4.25:
+    resolution: {integrity: sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.6
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
 
   /prelude-ls@1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -14573,25 +14970,19 @@ packages:
       fast-diff: 1.3.0
     dev: true
 
-  /prettier-plugin-ember-template-tag@1.0.2(prettier@2.8.8):
+  /prettier-plugin-ember-template-tag@1.0.2(prettier@3.1.0-dev):
     resolution: {integrity: sha512-skL3NH1ay/eTlrTSTtFxoHLBmZJIoTDrb2zOONClt01aKqs/8brh/9ZtnjjLHi9FUq5x/kJ8LCm+6BYmNp696Q==}
     engines: {node: 16.* || 18.* || >= 20}
     peerDependencies:
-      prettier: '>= 3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       '@babel/core': 7.22.10(supports-color@8.1.1)
       '@glimmer/syntax': 0.84.3
       ember-cli-htmlbars: 6.2.0
       ember-template-imports: 3.4.2
-      prettier: 2.8.8
+      prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
     dev: true
 
   /pretty-ms@3.2.0:
@@ -14705,6 +15096,10 @@ packages:
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: true
+
+  /pseudomap@1.0.2:
+    resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
     dev: true
 
   /psl@1.9.0:
@@ -14912,6 +15307,13 @@ packages:
       safe-regex: 1.1.0
     dev: true
 
+  /regexp-util@2.0.0:
+    resolution: {integrity: sha512-HbLDPF+RkBiPjlzmU0hnUQd4abs56JiA2riHxNVfxjagcGwIy3Xhc2Yyx2+0/p5QeM0kj270nEOlTj57HvWXFA==}
+    engines: {node: '>=16'}
+    dependencies:
+      tslib: 2.6.2
+    dev: true
+
   /regexp.prototype.flags@1.5.0:
     resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
     engines: {node: '>= 0.4'}
@@ -15029,6 +15431,35 @@ packages:
       - supports-color
     dev: true
 
+  /remark-footnotes@2.0.0:
+    resolution: {integrity: sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ==}
+    dev: true
+
+  /remark-math@3.0.1:
+    resolution: {integrity: sha512-epT77R/HK0x7NqrWHdSV75uNLwn8g9qTyMqCRCDujL0vj/6T6+yhdrR7mjELWtkse+Fw02kijAaBuVcHBor1+Q==}
+    dev: true
+
+  /remark-parse@8.0.3:
+    resolution: {integrity: sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==}
+    dependencies:
+      ccount: 1.1.0
+      collapse-white-space: 1.0.6
+      is-alphabetical: 1.0.4
+      is-decimal: 1.0.4
+      is-whitespace-character: 1.0.4
+      is-word-character: 1.0.4
+      markdown-escapes: 1.0.4
+      parse-entities: 2.0.0
+      repeat-string: 1.6.1
+      state-toggle: 1.0.3
+      trim: 0.0.1
+      trim-trailing-lines: 1.1.4
+      unherit: 1.1.3
+      unist-util-remove-position: 2.0.1
+      vfile-location: 3.2.0
+      xtend: 4.0.2
+    dev: true
+
   /remote-git-tags@3.0.0:
     resolution: {integrity: sha512-C9hAO4eoEsX+OXA4rla66pXZQ+TLQ8T9dttgQj18yuKlPMTVkIkdYXvlMC55IuUsIkV6DpmQYi10JKFLaU+l7w==}
     engines: {node: '>=8'}
@@ -15044,8 +15475,9 @@ packages:
       '@babel/core': 7.22.10(supports-color@8.1.1)
       '@babel/plugin-syntax-decorators': 7.22.5(@babel/core@7.22.10)
       '@babel/plugin-transform-typescript': 7.22.5(@babel/core@7.22.10)
-      prettier: 2.8.8
+      prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
     transitivePeerDependencies:
+      - '@angular/core'
       - supports-color
     dev: true
 
@@ -15507,6 +15939,15 @@ packages:
       ajv-keywords: 5.1.0(ajv@8.12.0)
     dev: true
 
+  /sdbm@2.0.0:
+    resolution: {integrity: sha512-dspMGxvHiwSTgyrmm90jHQV2sDqK46ssbDK+bQAlJ5aRuPo3C7So108V6rCuCDbm1CrNWuPeMpmTNQKPl7vO+A==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+    dev: true
+
   /semver-diff@4.0.0:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
     engines: {node: '>=12'}
@@ -15645,6 +16086,10 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.2.1
       object-inspect: 1.12.3
+    dev: true
+
+  /sigmund@1.0.1:
+    resolution: {integrity: sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==}
     dev: true
 
   /signal-exit@3.0.7:
@@ -15932,6 +16377,10 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /state-toggle@1.0.3:
+    resolution: {integrity: sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==}
     dev: true
 
   /static-extend@0.1.2:
@@ -16488,6 +16937,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /to-fast-properties@4.0.0:
+    resolution: {integrity: sha512-y4PM/CFhbderIl3OTBsHbdrh+pTCiv4pNlrPNlEUQCRxZc1o41fJDG7YNDunH2LVERQ4pR0n3G/yIKjxv8fgJw==}
+    engines: {node: '>=12.20'}
+    dev: true
+
   /to-object-path@0.3.0:
     resolution: {integrity: sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==}
     engines: {node: '>=0.10.0'}
@@ -16592,6 +17046,19 @@ packages:
       - supports-color
     dev: true
 
+  /trim-trailing-lines@1.1.4:
+    resolution: {integrity: sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==}
+    dev: true
+
+  /trim@0.0.1:
+    resolution: {integrity: sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==}
+    deprecated: Use String.prototype.trim() instead
+    dev: true
+
+  /trough@1.0.5:
+    resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
+    dev: true
+
   /ts-clone-node@2.0.4(typescript@4.9.5):
     resolution: {integrity: sha512-eG6FAgmQsenhIJOIFhUcO6yyYejBKZIKcI3y21jiQmIOrth5pD6GElyPAyeihbPSyBs3u/9PVNXy+5I7jGy8jA==}
     engines: {node: '>=14.9.0'}
@@ -16610,6 +17077,10 @@ packages:
     resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
     dev: true
 
+  /tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+    dev: true
+
   /tsutils@3.21.0(typescript@4.9.5):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -16618,6 +17089,16 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.9.5
+    dev: true
+
+  /tsutils@3.21.0(typescript@5.1.6):
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 5.1.6
     dev: true
 
   /type-check@0.3.2:
@@ -16690,6 +17171,12 @@ packages:
     hasBin: true
     dev: true
 
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
   /ua-parser-js@1.0.35:
     resolution: {integrity: sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==}
     dev: true
@@ -16725,6 +17212,13 @@ packages:
     resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
     dev: true
 
+  /unherit@1.1.3:
+    resolution: {integrity: sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==}
+    dependencies:
+      inherits: 2.0.4
+      xtend: 4.0.2
+    dev: true
+
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -16748,6 +17242,25 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /unicode-regex@4.0.0:
+    resolution: {integrity: sha512-Zdlz4CqHeCy1pw2J15RmCMw/9QLRBz+BykmI8YNbtbf4pIV8t+1fHKD7y13NhauPEvisi2e5SoaonBNX77opGA==}
+    engines: {node: '>=16'}
+    dependencies:
+      regexp-util: 2.0.0
+    dev: true
+
+  /unified@9.2.2:
+    resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
+    dependencies:
+      '@types/unist': 2.0.6
+      bail: 1.0.5
+      extend: 3.0.2
+      is-buffer: 2.0.5
+      is-plain-obj: 2.1.0
+      trough: 1.0.5
+      vfile: 4.2.1
+    dev: true
+
   /union-value@1.0.1:
     resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==}
     engines: {node: '>=0.10.0'}
@@ -16756,6 +17269,10 @@ packages:
       get-value: 2.0.6
       is-extendable: 0.1.1
       set-value: 2.0.1
+    dev: true
+
+  /uniq@1.0.1:
+    resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==}
     dev: true
 
   /unique-filename@1.1.1:
@@ -16784,10 +17301,41 @@ packages:
       crypto-random-string: 4.0.0
     dev: true
 
+  /unist-util-is@4.1.0:
+    resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
+    dev: true
+
+  /unist-util-remove-position@2.0.1:
+    resolution: {integrity: sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==}
+    dependencies:
+      unist-util-visit: 2.0.3
+    dev: true
+
+  /unist-util-stringify-position@2.0.3:
+    resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
+    dependencies:
+      '@types/unist': 2.0.6
+    dev: true
+
   /unist-util-stringify-position@3.0.3:
     resolution: {integrity: sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==}
     dependencies:
       '@types/unist': 2.0.6
+    dev: true
+
+  /unist-util-visit-parents@3.1.1:
+    resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-is: 4.1.0
+    dev: true
+
+  /unist-util-visit@2.0.3:
+    resolution: {integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-is: 4.1.0
+      unist-util-visit-parents: 3.1.1
     dev: true
 
   /universal-user-agent@6.0.0:
@@ -16977,6 +17525,26 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
+  /vfile-location@3.2.0:
+    resolution: {integrity: sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==}
+    dev: true
+
+  /vfile-message@2.0.4:
+    resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-stringify-position: 2.0.3
+    dev: true
+
+  /vfile@4.2.1:
+    resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
+    dependencies:
+      '@types/unist': 2.0.6
+      is-buffer: 2.0.5
+      unist-util-stringify-position: 2.0.3
+      vfile-message: 2.0.4
+    dev: true
+
   /vite@4.3.9(@types/node@18.16.16):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -17017,6 +17585,15 @@ packages:
     dependencies:
       acorn: 8.8.2
       acorn-walk: 8.2.0
+    dev: true
+
+  /vnopts@1.0.2:
+    resolution: {integrity: sha512-d2rr2EFhAGHnTlURu49G7GWmiJV80HbAnkYdD9IFAtfhmxC+kSWEaZ6ZF064DJFTv9lQZQV1vuLTntyQpoanGQ==}
+    engines: {node: '>= 6'}
+    dependencies:
+      chalk: 2.4.2
+      leven: 2.1.0
+      tslib: 1.14.1
     dev: true
 
   /vscode-jsonrpc@8.1.0:
@@ -17426,6 +18003,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /yallist@2.1.2:
+    resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
+    dev: true
+
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
     dev: true
@@ -17439,6 +18020,20 @@ packages:
     dependencies:
       fs-extra: 4.0.3
       lodash.merge: 4.6.2
+    dev: true
+
+  /yaml-unist-parser@2.0.1:
+    resolution: {integrity: sha512-SpgobpXX6nodBqAuVuU5zz6veNBDICfr4t3j+brFJtQrfmFjD5HsaDR1v2aDIUemSkc3mbA5Ghkp7LyfpPv+qw==}
+    engines: {node: '>= 14'}
+    dependencies:
+      lines-and-columns: 2.0.3
+      tslib: 2.5.3
+      yaml: 1.10.2
+    dev: true
+
+  /yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
     dev: true
 
   /yaml@2.3.1:
@@ -17490,4 +18085,90 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+    dev: true
+
+  github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6:
+    resolution: {tarball: https://codeload.github.com/cardstack/prettier/tar.gz/60eccfdc598d682a931d3c569ffb0c4f92ef5db6}
+    name: prettier
+    version: 3.1.0-dev
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      '@angular/compiler': 16.1.4
+      '@babel/code-frame': 7.22.5
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
+      '@glimmer/syntax': 0.84.3
+      '@iarna/toml': 2.2.5
+      '@prettier/is-es5-identifier-name': 0.2.0
+      '@prettier/parse-srcset': 3.0.0
+      '@typescript-eslint/typescript-estree': 5.61.0(typescript@5.1.6)
+      '@typescript-eslint/visitor-keys': 5.61.0
+      acorn: 8.10.0
+      acorn-jsx: 5.3.2(acorn@8.10.0)
+      angular-estree-parser: 7.0.0(@angular/compiler@16.1.4)
+      angular-html-parser: 4.0.1
+      camelcase: 7.0.1
+      chalk: 5.3.0
+      ci-info: 3.8.0
+      cjk-regex: 3.0.0
+      collapse-white-space: 1.0.6
+      cosmiconfig: 8.2.0
+      css-units-list: 2.0.1
+      dashify: 2.0.0
+      diff: 5.1.0
+      eastasianwidth: 0.2.0
+      editorconfig: 0.15.3
+      editorconfig-to-prettier: 1.0.0
+      emoji-regex: 10.2.1
+      escape-string-regexp: 5.0.0
+      espree: 9.6.0
+      fast-glob: 3.2.12
+      fast-json-stable-stringify: 2.1.0
+      file-entry-cache: 6.0.1
+      find-cache-dir: 4.0.0
+      find-parent-dir: 0.3.1
+      flow-parser: 0.211.1
+      get-stdin: 9.0.0
+      graphql: 16.7.1
+      hermes-parser: 0.14.0
+      html-element-attributes: 3.2.0
+      html-styles: 1.0.0
+      html-tag-names: 2.1.0
+      ignore: 5.2.4
+      import-meta-resolve: 3.0.0
+      jest-docblock: 29.4.3
+      json5: 2.2.3
+      leven: 4.0.0
+      lines-and-columns: 2.0.3
+      linguist-languages: 7.21.0
+      mem: 9.0.2
+      meriyah: 4.3.7
+      micromatch: 4.0.5
+      minimist: 1.2.8
+      n-readlines: 1.0.1
+      outdent: 0.8.0
+      please-upgrade-node: 3.2.0
+      postcss: 8.4.25
+      postcss-less: 6.0.0(postcss@8.4.25)
+      postcss-media-query-parser: 0.2.3
+      postcss-scss: 4.0.6(postcss@8.4.25)
+      postcss-selector-parser: 2.2.3
+      postcss-values-parser: 2.0.1
+      regexp-util: 2.0.0
+      remark-footnotes: 2.0.0
+      remark-math: 3.0.1
+      remark-parse: 8.0.3
+      sdbm: 2.0.0
+      strip-ansi: 7.1.0
+      to-fast-properties: 4.0.0
+      typescript: 5.1.6
+      unicode-regex: 4.0.0
+      unified: 9.2.2
+      vnopts: 1.0.2
+      wcwidth: 1.0.1
+      yaml-unist-parser: 2.0.1
+    transitivePeerDependencies:
+      - '@angular/core'
+      - supports-color
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,8 +210,8 @@ importers:
         specifier: ^15.7.0
         version: 15.7.0(eslint@8.42.0)
       eslint-plugin-prettier:
-        specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@3.1.0-dev)
+        specifier: ^5.0.0
+        version: 5.1.3(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@3.1.0-dev)
       eslint-plugin-qunit:
         specifier: ^7.3.4
         version: 7.3.4(eslint@8.42.0)
@@ -394,8 +394,8 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0(eslint@7.32.0)
       eslint-plugin-prettier:
-        specifier: ^4.0.0
-        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@7.32.0)(prettier@3.1.0-dev)
+        specifier: ^5.0.0
+        version: 5.1.3(eslint-config-prettier@8.8.0)(eslint@7.32.0)(prettier@3.1.0-dev)
       prettier:
         specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
         version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
@@ -604,8 +604,8 @@ importers:
         specifier: ^15.7.0
         version: 15.7.0(eslint@8.42.0)
       eslint-plugin-prettier:
-        specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@3.1.0-dev)
+        specifier: ^5.0.0
+        version: 5.1.3(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@3.1.0-dev)
       eslint-plugin-qunit:
         specifier: ^7.3.4
         version: 7.3.4(eslint@8.42.0)
@@ -4455,6 +4455,11 @@ packages:
       '@octokit/openapi-types': 17.2.0
     dev: true
 
+  /@pkgr/core@0.1.1:
+    resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    dev: true
+
   /@pmmmwh/react-refresh-webpack-plugin@0.5.10(react-refresh@0.14.0)(webpack@5.86.0):
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
     engines: {node: '>= 10.13'}
@@ -4734,7 +4739,7 @@ packages:
   /@swc/helpers@0.5.1:
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /@szmarczak/http-timer@1.1.2:
@@ -6216,7 +6221,7 @@ packages:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /astral-regex@2.0.0:
@@ -9029,7 +9034,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /dot-prop@5.3.0:
@@ -10304,14 +10309,17 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@7.32.0)(prettier@3.1.0-dev):
-    resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
-    engines: {node: '>=12.0.0'}
+  /eslint-plugin-prettier@5.1.3(eslint-config-prettier@8.8.0)(eslint@7.32.0)(prettier@3.1.0-dev):
+    resolution: {integrity: sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      eslint: '>=7.28.0'
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
       eslint-config-prettier: '*'
       prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
       eslint-config-prettier:
         optional: true
     dependencies:
@@ -10319,16 +10327,20 @@ packages:
       eslint-config-prettier: 8.8.0(eslint@7.32.0)
       prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       prettier-linter-helpers: 1.0.0
+      synckit: 0.8.8
     dev: true
 
-  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@3.1.0-dev):
-    resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
-    engines: {node: '>=12.0.0'}
+  /eslint-plugin-prettier@5.1.3(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@3.1.0-dev):
+    resolution: {integrity: sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      eslint: '>=7.28.0'
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
       eslint-config-prettier: '*'
       prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
       eslint-config-prettier:
         optional: true
     dependencies:
@@ -10336,6 +10348,7 @@ packages:
       eslint-config-prettier: 8.8.0(eslint@8.42.0)
       prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       prettier-linter-helpers: 1.0.0
+      synckit: 0.8.8
     dev: true
 
   /eslint-plugin-qunit@7.3.4(eslint@8.42.0):
@@ -13338,7 +13351,7 @@ packages:
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /lowercase-keys@1.0.1:
@@ -14109,7 +14122,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /node-domexception@1.0.0:
@@ -16643,6 +16656,14 @@ packages:
       username-sync: 1.0.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /synckit@0.8.8:
+    resolution: {integrity: sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    dependencies:
+      '@pkgr/core': 0.1.1
+      tslib: 2.6.2
     dev: true
 
   /table@6.8.1:

--- a/test-app/app/components/uses-scoped-classes.gjs
+++ b/test-app/app/components/uses-scoped-classes.gjs
@@ -5,10 +5,16 @@ import { concat } from '@ember/helper';
 export default class UsesScopedClasses extends Component {
   <template>
     <DynamicallyInsertsElements
-      @detailsClass="__GLIMMER_SCOPED_CSS_CLASS"
-      @timeClass={{concat "something " (concat "somethingelse " "__GLIMMER_SCOPED_CSS_CLASS")}}
-      @dataClass="{{this.aString}} __GLIMMER_SCOPED_CSS_CLASS"
-      @codeClass="a-class {{concat "another-class " "__GLIMMER_SCOPED_CSS_CLASS"}}"
+      @detailsClass='__GLIMMER_SCOPED_CSS_CLASS'
+      @timeClass={{concat
+        'something '
+        (concat 'somethingelse ' '__GLIMMER_SCOPED_CSS_CLASS')
+      }}
+      @dataClass='{{this.aString}} __GLIMMER_SCOPED_CSS_CLASS'
+      @codeClass='a-class {{concat
+        "another-class "
+        "__GLIMMER_SCOPED_CSS_CLASS"
+      }}'
       data-test-dynamic-container
     />
     <style>
@@ -37,18 +43,26 @@ export default class UsesScopedClasses extends Component {
 
 class DynamicallyInsertsElements extends Component {
   <template>
-    <section {{InsertChildElementsModifier detailsClass=@detailsClass timeClass=@timeClass dataClass=@dataClass codeClass=@codeClass}} ...attributes>
+    <section
+      {{InsertChildElementsModifier
+        detailsClass=@detailsClass
+        timeClass=@timeClass
+        dataClass=@dataClass
+        codeClass=@codeClass
+      }}
+      ...attributes
+    >
       I have children inserted dynamically with a scoped class.
     </section>
   </template>
-
-  get aString() {
-    return 'a string';
-  }
-};
+}
 
 class InsertChildElementsModifier extends Modifier {
-  modify(element, _positional, { detailsClass, timeClass, dataClass, codeClass }) {
+  modify(
+    element,
+    _positional,
+    { detailsClass, timeClass, dataClass, codeClass },
+  ) {
     let document = element.ownerDocument;
 
     let details = document.createElement('details');
@@ -74,5 +88,5 @@ class InsertChildElementsModifier extends Modifier {
     code.className = codeClass;
     code.textContent = 'code';
     element.appendChild(code);
-    }
+  }
 }

--- a/test-app/app/components/uses-scoped-classes.gjs
+++ b/test-app/app/components/uses-scoped-classes.gjs
@@ -4,13 +4,12 @@ import { concat } from '@ember/helper';
 
 export default class UsesScopedClasses extends Component {
   <template>
-    before
+
     <DynamicallyInsertsElements
       @detailsClass="__GLIMMER_SCOPED_CSS_CLASS"
       @timeClass={{concat "something " "__GLIMMER_SCOPED_CSS_CLASS"}}
-      data-test-details-container
+      data-test-dynamic-container
     />
-    after!!!!
     <style>
       details.__GLIMMER_SCOPED_CSS_CLASS {
         background-color: lightblue;

--- a/test-app/app/components/uses-scoped-classes.gjs
+++ b/test-app/app/components/uses-scoped-classes.gjs
@@ -7,7 +7,7 @@ export default class UsesScopedClasses extends Component {
 
     <DynamicallyInsertsElements
       @detailsClass="__GLIMMER_SCOPED_CSS_CLASS"
-      @timeClass={{concat "something " "__GLIMMER_SCOPED_CSS_CLASS"}}
+      @timeClass={{concat "something " (concat "somethingelse " "__GLIMMER_SCOPED_CSS_CLASS")}}
       data-test-dynamic-container
     />
     <style>

--- a/test-app/app/components/uses-scoped-classes.gjs
+++ b/test-app/app/components/uses-scoped-classes.gjs
@@ -35,7 +35,7 @@ class DynamicallyInsertsElements extends Component {
   </template>
 };
 
-class InsertChildElementsModifier extends Modifier<ScrollSignature> {
+class InsertChildElementsModifier extends Modifier {
   modify(element, _positional, { detailsClass, timeClass }) {
     let document = element.ownerDocument;
 

--- a/test-app/app/components/uses-scoped-classes.gjs
+++ b/test-app/app/components/uses-scoped-classes.gjs
@@ -21,11 +21,11 @@ export default class UsesScopedClasses extends Component {
       }
     </style>
   </template>
+
+  get aString() {
+    return 'a string';
+  }
 }
-
-
-
-
 
 class DynamicallyInsertsElements extends Component {
   <template>
@@ -33,6 +33,10 @@ class DynamicallyInsertsElements extends Component {
       I have children inserted dynamically with a scoped class.
     </section>
   </template>
+
+  get aString() {
+    return 'a string';
+  }
 };
 
 class InsertChildElementsModifier extends Modifier {

--- a/test-app/app/components/uses-scoped-classes.gjs
+++ b/test-app/app/components/uses-scoped-classes.gjs
@@ -1,29 +1,44 @@
 import Component from '@glimmer/component';
 import Modifier from 'ember-modifier';
+import { concat } from '@ember/helper';
 
 export default class UsesScopedClasses extends Component {
   <template>
-    <DynamicallyInsertsElements @detailsClass="__GLIMMER_SCOPED_CSS_CLASS" data-test-details-container />
+    before
+    <DynamicallyInsertsElements
+      @detailsClass="__GLIMMER_SCOPED_CSS_CLASS"
+      @timeClass={{concat "something " "__GLIMMER_SCOPED_CSS_CLASS"}}
+      data-test-details-container
+    />
+    after!!!!
     <style>
-      .__GLIMMER_SCOPED_CSS_CLASS {
+      details.__GLIMMER_SCOPED_CSS_CLASS {
         background-color: lightblue;
+      }
+
+      time.__GLIMMER_SCOPED_CSS_CLASS {
+        background-color: limegreen;
       }
     </style>
   </template>
 }
 
+
+
+
+
 class DynamicallyInsertsElements extends Component {
   <template>
-    <section {{InsertChildElementsModifier detailsClass=@detailsClass}} ...attributes>
+    <section {{InsertChildElementsModifier detailsClass=@detailsClass timeClass=@timeClass}} ...attributes>
       I have children inserted dynamically with a scoped class.
     </section>
   </template>
 };
 
-
 class InsertChildElementsModifier extends Modifier<ScrollSignature> {
-  modify(element, [], {detailsClass}) {
+  modify(element, [], { detailsClass, timeClass, xyz }) {
     let document = element.ownerDocument;
+
     let details = document.createElement('details');
     details.className = detailsClass;
     details.innerHTML = `
@@ -31,5 +46,10 @@ class InsertChildElementsModifier extends Modifier<ScrollSignature> {
       <p>Here is some content</p>
     `;
     element.appendChild(details);
+
+    let time = document.createElement('time');
+    time.className = timeClass;
+    time.textContent = new Date().toLocaleTimeString();
+    element.appendChild(time);
     }
 }

--- a/test-app/app/components/uses-scoped-classes.gjs
+++ b/test-app/app/components/uses-scoped-classes.gjs
@@ -4,10 +4,11 @@ import { concat } from '@ember/helper';
 
 export default class UsesScopedClasses extends Component {
   <template>
-
     <DynamicallyInsertsElements
       @detailsClass="__GLIMMER_SCOPED_CSS_CLASS"
       @timeClass={{concat "something " (concat "somethingelse " "__GLIMMER_SCOPED_CSS_CLASS")}}
+      @dataClass="{{this.aString}} __GLIMMER_SCOPED_CSS_CLASS"
+      @codeClass="a-class {{concat "another-class " "__GLIMMER_SCOPED_CSS_CLASS"}}"
       data-test-dynamic-container
     />
     <style>
@@ -18,17 +19,25 @@ export default class UsesScopedClasses extends Component {
       time.__GLIMMER_SCOPED_CSS_CLASS {
         background-color: limegreen;
       }
+
+      data.__GLIMMER_SCOPED_CSS_CLASS {
+        font-style: italic;
+      }
+
+      code.__GLIMMER_SCOPED_CSS_CLASS {
+        font-style: italic;
+      }
     </style>
   </template>
 
   get aString() {
-    return 'a string';
+    return 'a-string';
   }
 }
 
 class DynamicallyInsertsElements extends Component {
   <template>
-    <section {{InsertChildElementsModifier detailsClass=@detailsClass timeClass=@timeClass}} ...attributes>
+    <section {{InsertChildElementsModifier detailsClass=@detailsClass timeClass=@timeClass dataClass=@dataClass codeClass=@codeClass}} ...attributes>
       I have children inserted dynamically with a scoped class.
     </section>
   </template>
@@ -39,7 +48,7 @@ class DynamicallyInsertsElements extends Component {
 };
 
 class InsertChildElementsModifier extends Modifier {
-  modify(element, _positional, { detailsClass, timeClass }) {
+  modify(element, _positional, { detailsClass, timeClass, dataClass, codeClass }) {
     let document = element.ownerDocument;
 
     let details = document.createElement('details');
@@ -54,5 +63,16 @@ class InsertChildElementsModifier extends Modifier {
     time.className = timeClass;
     time.textContent = new Date().toLocaleTimeString();
     element.appendChild(time);
+
+    let data = document.createElement('data');
+    data.className = dataClass;
+    data.value = 'xyz';
+    data.innerHTML = 'xyz';
+    element.appendChild(data);
+
+    let code = document.createElement('code');
+    code.className = codeClass;
+    code.textContent = 'code';
+    element.appendChild(code);
     }
 }

--- a/test-app/app/components/uses-scoped-classes.gjs
+++ b/test-app/app/components/uses-scoped-classes.gjs
@@ -41,21 +41,19 @@ export default class UsesScopedClasses extends Component {
   }
 }
 
-class DynamicallyInsertsElements extends Component {
-  <template>
-    <section
-      {{InsertChildElementsModifier
-        detailsClass=@detailsClass
-        timeClass=@timeClass
-        dataClass=@dataClass
-        codeClass=@codeClass
-      }}
-      ...attributes
-    >
-      I have children inserted dynamically with a scoped class.
-    </section>
-  </template>
-}
+const DynamicallyInsertsElements = <template>
+  <section
+    {{InsertChildElementsModifier
+      detailsClass=@detailsClass
+      timeClass=@timeClass
+      dataClass=@dataClass
+      codeClass=@codeClass
+    }}
+    ...attributes
+  >
+    I have children inserted dynamically with a scoped class.
+  </section>
+</template>;
 
 class InsertChildElementsModifier extends Modifier {
   modify(

--- a/test-app/app/components/uses-scoped-classes.gjs
+++ b/test-app/app/components/uses-scoped-classes.gjs
@@ -5,7 +5,7 @@ export default class UsesScopedClasses extends Component {
   <template>
     <DynamicallyInsertsElements @detailsClass="__GLIMMER_SCOPED_CSS_CLASS" data-test-details-container />
     <style>
-      :global(.__GLIMMER_SCOPED_CSS_CLASS) {
+      .__GLIMMER_SCOPED_CSS_CLASS {
         background-color: lightblue;
       }
     </style>

--- a/test-app/app/components/uses-scoped-classes.gjs
+++ b/test-app/app/components/uses-scoped-classes.gjs
@@ -1,0 +1,51 @@
+import Component from '@glimmer/component';
+import Modifier from 'ember-modifier';
+
+export default class UsesScopedClasses extends Component {
+  <template>
+    <DynamicallyInsertsElements @detailsClass="__GLIMMER_SCOPED_CSS_CLASS" data-test-details-container />
+    <style>
+      :global(.__GLIMMER_SCOPED_CSS_CLASS) {
+        background-color: lightblue;
+      }
+    </style>
+  </template>
+}
+
+class DynamicallyInsertsElements extends Component {
+  <template>
+    <section {{InsertChildElementsModifier detailsClass=@detailsClass}} ...attributes>
+      I have children inserted dynamically with a scoped class.
+    </section>
+  </template>
+};
+
+
+class InsertChildElementsModifier extends Modifier<ScrollSignature> {
+  modify(element, [], {detailsClass}) {
+    let document = element.ownerDocument;
+    let details = document.createElement('details');
+    details.className = detailsClass;
+    details.innerHTML = `
+      <summary>Click me</summary>
+      <p>Here is some content</p>
+    `;
+    element.appendChild(details);
+    }
+  //   element: HTMLElement,
+  //   _positional: [],
+  //   { initialScrollPosition = 0, onScroll }: ScrollSignature['Args']['Named'],
+  // ) {
+  //   // note that when testing make sure "disable cache" in chrome network settings is unchecked,
+  //   // as this assumes that previously loaded images will be cached. otherwise the scroll will
+  //   // happen *before* the geometry is altered by images that haven't completed loading yet.
+  //   element.documentElement.scrollTop = initialScrollPosition;
+  //   element.scrollTop = initialScrollPosition;
+  //   if (onScroll) {
+  //     element.addEventListener('scroll', onScroll);
+  //     registerDestructor(this, () => {
+  //       element.removeEventListener('scroll', onScroll);
+  //     });
+  //   }
+  // }
+}

--- a/test-app/app/components/uses-scoped-classes.gjs
+++ b/test-app/app/components/uses-scoped-classes.gjs
@@ -32,20 +32,4 @@ class InsertChildElementsModifier extends Modifier<ScrollSignature> {
     `;
     element.appendChild(details);
     }
-  //   element: HTMLElement,
-  //   _positional: [],
-  //   { initialScrollPosition = 0, onScroll }: ScrollSignature['Args']['Named'],
-  // ) {
-  //   // note that when testing make sure "disable cache" in chrome network settings is unchecked,
-  //   // as this assumes that previously loaded images will be cached. otherwise the scroll will
-  //   // happen *before* the geometry is altered by images that haven't completed loading yet.
-  //   element.documentElement.scrollTop = initialScrollPosition;
-  //   element.scrollTop = initialScrollPosition;
-  //   if (onScroll) {
-  //     element.addEventListener('scroll', onScroll);
-  //     registerDestructor(this, () => {
-  //       element.removeEventListener('scroll', onScroll);
-  //     });
-  //   }
-  // }
 }

--- a/test-app/app/components/uses-scoped-classes.gjs
+++ b/test-app/app/components/uses-scoped-classes.gjs
@@ -36,7 +36,7 @@ class DynamicallyInsertsElements extends Component {
 };
 
 class InsertChildElementsModifier extends Modifier<ScrollSignature> {
-  modify(element, [], { detailsClass, timeClass, xyz }) {
+  modify(element, _positional, { detailsClass, timeClass, xyz }) {
     let document = element.ownerDocument;
 
     let details = document.createElement('details');

--- a/test-app/app/components/uses-scoped-classes.gjs
+++ b/test-app/app/components/uses-scoped-classes.gjs
@@ -36,7 +36,7 @@ class DynamicallyInsertsElements extends Component {
 };
 
 class InsertChildElementsModifier extends Modifier<ScrollSignature> {
-  modify(element, _positional, { detailsClass, timeClass, xyz }) {
+  modify(element, _positional, { detailsClass, timeClass }) {
     let document = element.ownerDocument;
 
     let details = document.createElement('details');

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -16,4 +16,6 @@
 
 <UsesAnImport />
 
+<UsesScopedClasses />
+
 {{outlet}}

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -83,7 +83,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-ember": "^11.5.0",
     "eslint-plugin-n": "^15.7.0",
-    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-qunit": "^7.3.4",
     "glimmer-scoped-css": "^0.4.1",
     "loader.js": "^4.7.0",

--- a/test-app/tests/acceptance/scoped-css-test.ts
+++ b/test-app/tests/acceptance/scoped-css-test.ts
@@ -95,34 +95,34 @@ module('Acceptance | scoped css', function (hooks) {
   test('the __GLIMMER_SCOPED_CSS_CLASS is replaced in attribute strings and styles', async function (assert) {
     await visit('/');
 
-    const detailsContainer = find('[data-test-details-container]');
+    const dynamicContainer = find('[data-test-dynamic-container]');
 
-    if (!detailsContainer) {
-      throw new Error('[data-test-details-container] element not found');
+    if (!dynamicContainer) {
+      throw new Error('[data-test-dynamic-container] element not found');
     }
 
-    const detailsContainerScopedCssSelector = Array.from(
-      detailsContainer.attributes
+    const dynamicContainerScopedCssSelector = Array.from(
+      dynamicContainer.attributes
     )
       .map((attribute) => attribute.localName)
       .find((attributeName) => attributeName.startsWith('data-scopedcss'));
 
-    if (!detailsContainerScopedCssSelector) {
+    if (!dynamicContainerScopedCssSelector) {
       throw new Error(
-        'Scoped CSS selector not found on [data-test-details-container]'
+        'Scoped CSS selector not found on [data-test-dynamic-container]'
       );
     }
 
     assert
-      .dom('[data-test-details-container] details')
-      .hasClass(detailsContainerScopedCssSelector)
+      .dom('[data-test-dynamic-container] details')
+      .hasClass(dynamicContainerScopedCssSelector)
       .hasStyle({
         'background-color': 'rgb(173, 216, 230)',
       });
 
     assert
-      .dom('[data-test-details-container] time')
-      .hasClass(detailsContainerScopedCssSelector)
+      .dom('[data-test-dynamic-container] time')
+      .hasClass(dynamicContainerScopedCssSelector)
       .hasStyle({
         'background-color': 'rgb(50, 205, 50)',
       });

--- a/test-app/tests/acceptance/scoped-css-test.ts
+++ b/test-app/tests/acceptance/scoped-css-test.ts
@@ -129,6 +129,20 @@ module('Acceptance | scoped css', function (hooks) {
       .hasStyle({
         'background-color': 'rgb(50, 205, 50)',
       });
+
+    assert
+      .dom('[data-test-dynamic-container] data')
+      .hasClass(dynamicContainerScopedCssClass)
+      .hasStyle({
+        'font-style': 'italic',
+      });
+
+    assert
+      .dom('[data-test-dynamic-container] code')
+      .hasClass(dynamicContainerScopedCssClass)
+      .hasStyle({
+        'font-style': 'italic',
+      });
   });
 
   test('unscoped style elements are passed through without the unscoped attribute', async function (assert) {

--- a/test-app/tests/acceptance/scoped-css-test.ts
+++ b/test-app/tests/acceptance/scoped-css-test.ts
@@ -101,28 +101,31 @@ module('Acceptance | scoped css', function (hooks) {
       throw new Error('[data-test-dynamic-container] element not found');
     }
 
-    const dynamicContainerScopedCssSelector = Array.from(
+    const prefixedDynamicContainerScopedCssSelector = Array.from(
       dynamicContainer.attributes
     )
       .map((attribute) => attribute.localName)
       .find((attributeName) => attributeName.startsWith('data-scopedcss'));
 
-    if (!dynamicContainerScopedCssSelector) {
+    if (!prefixedDynamicContainerScopedCssSelector) {
       throw new Error(
         'Scoped CSS selector not found on [data-test-dynamic-container]'
       );
     }
 
+    const dynamicContainerScopedCssClass =
+      prefixedDynamicContainerScopedCssSelector.replace(/^data-/, '');
+
     assert
       .dom('[data-test-dynamic-container] details')
-      .hasClass(dynamicContainerScopedCssSelector)
+      .hasClass(dynamicContainerScopedCssClass)
       .hasStyle({
         'background-color': 'rgb(173, 216, 230)',
       });
 
     assert
       .dom('[data-test-dynamic-container] time')
-      .hasClass(dynamicContainerScopedCssSelector)
+      .hasClass(dynamicContainerScopedCssClass)
       .hasStyle({
         'background-color': 'rgb(50, 205, 50)',
       });

--- a/test-app/tests/acceptance/scoped-css-test.ts
+++ b/test-app/tests/acceptance/scoped-css-test.ts
@@ -17,7 +17,7 @@ module('Acceptance | scoped css', function (hooks) {
     }
 
     const outerComponentScopedCssSelector = Array.from(
-      outerH1Element.attributes
+      outerH1Element.attributes,
     )
       .map((attribute) => attribute.localName)
       .find((attributeName) => attributeName.startsWith('data-scopedcss'));
@@ -35,7 +35,7 @@ module('Acceptance | scoped css', function (hooks) {
       .hasAttribute(
         outerComponentScopedCssSelector,
         '',
-        'expected splattributes element within nested component to inherit scoped CSS selector'
+        'expected splattributes element within nested component to inherit scoped CSS selector',
       );
     assert
       .dom('[data-test-inner-second-p]')
@@ -48,14 +48,14 @@ module('Acceptance | scoped css', function (hooks) {
     }
 
     const innerComponentScopedCssSelector = Array.from(
-      innerSecondParagraphElement.attributes
+      innerSecondParagraphElement.attributes,
     )
       .map((attribute) => attribute.localName)
       .find((attributeName) => attributeName.startsWith('data-scopedcss'));
 
     assert.notOk(
       innerComponentScopedCssSelector,
-      'expected [data-test-inner-second-p] to not have scoping attribute'
+      'expected [data-test-inner-second-p] to not have scoping attribute',
     );
 
     assert
@@ -63,7 +63,7 @@ module('Acceptance | scoped css', function (hooks) {
       .hasAttribute(
         outerComponentScopedCssSelector,
         '',
-        'expected splattributes element within nested component to have its parent component’s scoped CSS selector'
+        'expected splattributes element within nested component to have its parent component’s scoped CSS selector',
       );
   });
 
@@ -102,14 +102,14 @@ module('Acceptance | scoped css', function (hooks) {
     }
 
     const prefixedDynamicContainerScopedCssSelector = Array.from(
-      dynamicContainer.attributes
+      dynamicContainer.attributes,
     )
       .map((attribute) => attribute.localName)
       .find((attributeName) => attributeName.startsWith('data-scopedcss'));
 
     if (!prefixedDynamicContainerScopedCssSelector) {
       throw new Error(
-        'Scoped CSS selector not found on [data-test-dynamic-container]'
+        'Scoped CSS selector not found on [data-test-dynamic-container]',
       );
     }
 

--- a/test-app/tests/acceptance/scoped-css-test.ts
+++ b/test-app/tests/acceptance/scoped-css-test.ts
@@ -119,6 +119,13 @@ module('Acceptance | scoped css', function (hooks) {
       .hasStyle({
         'background-color': 'rgb(173, 216, 230)',
       });
+
+    assert
+      .dom('[data-test-details-container] time')
+      .hasClass(detailsContainerScopedCssSelector)
+      .hasStyle({
+        'background-color': 'rgb(50, 205, 50)',
+      });
   });
 
   test('unscoped style elements are passed through without the unscoped attribute', async function (assert) {

--- a/test-app/tests/acceptance/scoped-css-test.ts
+++ b/test-app/tests/acceptance/scoped-css-test.ts
@@ -92,6 +92,35 @@ module('Acceptance | scoped css', function (hooks) {
     });
   });
 
+  test('the __GLIMMER_SCOPED_CSS_CLASS is replaced in attribute strings and styles', async function (assert) {
+    await visit('/');
+
+    const detailsContainer = find('[data-test-details-container]');
+
+    if (!detailsContainer) {
+      throw new Error('[data-test-details-container] element not found');
+    }
+
+    const detailsContainerScopedCssSelector = Array.from(
+      detailsContainer.attributes
+    )
+      .map((attribute) => attribute.localName)
+      .find((attributeName) => attributeName.startsWith('data-scopedcss'));
+
+    if (!detailsContainerScopedCssSelector) {
+      throw new Error(
+        'Scoped CSS selector not found on [data-test-details-container]'
+      );
+    }
+
+    assert
+      .dom('[data-test-details-container] details')
+      .hasClass(detailsContainerScopedCssSelector)
+      .hasStyle({
+        'background-color': 'rgb(173, 216, 230)',
+      });
+  });
+
   test('unscoped style elements are passed through without the unscoped attribute', async function (assert) {
     await visit('/');
 


### PR DESCRIPTION
On hold: we’ve decided this isn’t worth the increased complexity, it can be accomplished with `:global` and a unique class name instead. **If you would find this feature useful, please let us know in the comments.**

<hr />

This adds a `__GLIMMER_SCOPED_CSS_CLASS` that facilitates style scoping even when working with code we don’t control that generates elements dynamically, such as Ember Power Select.

See [here](https://astexplorer.net/#/gist/116e3683ba4bf5e51539f46bc8de34c1/664b4d5839992628209a26cf77f1a44acbf3a020) for the AST for the test component.

There are some irksome formatting-only changes, I changed it to use the same Prettier branch as cardstack/boxel because format-on-save was causing `test-app/app/components/uses-scoped-classes.gjs` to become empty 😖