### PR TITLE
Change to require explicit scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This is a pre-1.0 release with several limitations:
 - it hardcodes Webpack CSS loaders
   - this works fine when you have the default loaders configured by `@embroider/webpack`
 - the styles are in a `style` element in `index.html`, not linked
+- scoped styles cannot use interpolation: `{{whatever}}` will be duplicated unprocessed in the stylesheet
 - there is log noise about source maps like this:
   ```
   unexpectedly found "<style>\n  p { color: blue" when slicing source, but expected "data-scopedcss-53259f1da9-58ccb4dfe0"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 If you have `app/components/something.hbs`:
 
 ```html
-<style>
+<style scoped>
   p {
     color: blue;
   }
@@ -219,9 +219,11 @@ ember install glimmer-scoped-css
 
 ## Usage
 
-Add a top-level `<style>` element in your component `.hbs` file and it will be scoped to elements in that component only. It also works in [`<template>` in `.gjs`/`.gts` files](https://github.com/ember-template-imports/ember-template-imports).
+Add a top-level `<style scoped>` element in your component `.hbs` file and it will be scoped to elements in that component only. It also works in [`<template>` in `.gjs`/`.gts` files](https://github.com/ember-template-imports/ember-template-imports).
 
 Nested `<style>` elements cannot be processed for scoping. Use `<style unscoped>` if you need a nested element, it will not receive scoping attributes and will be passed through to output without the `unscoped` attribute.
+
+FIXME is it still true re nesting? But unscoped is no longer needed regardless…
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -221,9 +221,7 @@ ember install glimmer-scoped-css
 
 Add a top-level `<style scoped>` element in your component `.hbs` file and it will be scoped to elements in that component only. It also works in [`<template>` in `.gjs`/`.gts` files](https://github.com/ember-template-imports/ember-template-imports).
 
-Nested `<style>` elements cannot be processed for scoping. Use `<style unscoped>` if you need a nested element, it will not receive scoping attributes and will be passed through to output without the `unscoped` attribute.
-
-FIXME is it still true re nesting? But unscoped is no longer needed regardless…
+Nested `<style scoped>` elements cannot be processed for scoping. Use `<style>` directly if you need a nested element, it will not receive scoping attributes and will be passed through to output.
 
 ## Architecture
 

--- a/failing-test-app/app/components/component.hbs
+++ b/failing-test-app/app/components/component.hbs
@@ -1,6 +1,6 @@
 <p>
   Outer p.
-  <style>
+  <style scoped>
     p { color: blue; }
   </style>
 </p>

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -51,6 +51,7 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
 
         if (node.tag === 'style') {
           if (walker.parent?.node.type !== 'Template') {
+            // FIXME again, is this still true?
             throw new Error(
               '<style> tags must be at the root of the template, they cannot be nested'
             );
@@ -58,12 +59,12 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
           let inputCSS = textContent(node);
           let outputCSS;
 
-          if (hasUnscopedAttribute(node)) {
-            outputCSS = inputCSS;
-          } else {
+          if (hasScopedAttribute(node)) {
             outputCSS = postcss([scopedStylesPlugin(dataAttribute)]).process(
               inputCSS
             ).css;
+          } else {
+            return;
           }
 
           // TODO: hard coding the loader chain means we ignore the other
@@ -101,10 +102,10 @@ function textContent(node: ASTv1.ElementNode): string {
   return textChildren.map((c) => c.chars).join('');
 }
 
-const UNSCOPED_ATTRIBUTE_NAME = 'unscoped';
+const SCOPED_ATTRIBUTE_NAME = 'scoped';
 
-function hasUnscopedAttribute(node: ASTv1.ElementNode): boolean {
+function hasScopedAttribute(node: ASTv1.ElementNode): boolean {
   return node.attributes.some(
-    (attribute) => attribute.name === UNSCOPED_ATTRIBUTE_NAME
+    (attribute) => attribute.name === SCOPED_ATTRIBUTE_NAME
   );
 }

--- a/glimmer-scoped-css/src/ast-transform.ts
+++ b/glimmer-scoped-css/src/ast-transform.ts
@@ -50,16 +50,16 @@ const scopedCSSTransform: ASTPluginBuilder<Env> = (env) => {
         let dataAttribute = `${dataAttributePrefix}-${currentTemplateStyleHash}`;
 
         if (node.tag === 'style') {
-          if (walker.parent?.node.type !== 'Template') {
-            // FIXME again, is this still true?
-            throw new Error(
-              '<style> tags must be at the root of the template, they cannot be nested'
-            );
-          }
           let inputCSS = textContent(node);
           let outputCSS;
 
           if (hasScopedAttribute(node)) {
+            if (walker.parent?.node.type !== 'Template') {
+              throw new Error(
+                '<style> tags must be at the root of the template, they cannot be nested'
+              );
+            }
+
             outputCSS = postcss([scopedStylesPlugin(dataAttribute)]).process(
               inputCSS
             ).css;

--- a/test-addon-to-import/src/components/underlined-addon-component.gjs
+++ b/test-addon-to-import/src/components/underlined-addon-component.gjs
@@ -1,6 +1,6 @@
 const UnderlinedAddonComponent = <template>
   {{! template-lint-disable no-forbidden-elements }}
-  <style data-test-scoped-underline-addon-component-style>
+  <style scoped data-test-scoped-underline-addon-component-style>
     .underlined-component { text-decoration: underline solid rgb(0, 0, 0); }
   </style>
 

--- a/test-addon-to-import/src/components/unscoped-addon-component.gjs
+++ b/test-addon-to-import/src/components/unscoped-addon-component.gjs
@@ -1,6 +1,6 @@
 const UnscopedAddonComponent = <template>
   {{! template-lint-disable no-forbidden-elements }}
-  <style unscoped data-test-addon-component-style>
+  <style data-test-addon-component-style>
     .addon-component { text-decoration: underline solid rgb(0, 0, 0); }
   </style>
 

--- a/test-app/app/components/has-interpolated-style.gjs
+++ b/test-app/app/components/has-interpolated-style.gjs
@@ -1,0 +1,21 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+export default class HasInterpolatedStyle extends Component {
+  @tracked color = 'pink';
+
+  updateColor = (event) => {
+    this.color = event.target.value;
+  };
+
+  <template>
+    <label>Color of text in field:</label>
+    <input class='interpolated-style-input' value={{this.color}} {{on 'change' this.updateColor}} />
+    <style>
+      .interpolated-style-input {
+        color: {{this.color}};
+      }
+    </style>
+  </template>
+}

--- a/test-app/app/components/multiple.gjs
+++ b/test-app/app/components/multiple.gjs
@@ -4,7 +4,7 @@ import UnscopedAddonComponent from 'test-addon-to-import/components/unscoped-add
 const MultipleInner = <template>
   <UnscopedAddonComponent />
   <p data-test-multiple-inner>Multiple inner</p>
-  <style>
+  <style scoped>
     p {
       font-weight: 700;
     }
@@ -12,14 +12,14 @@ const MultipleInner = <template>
 </template>;
 
 const MultipleOuter = <template>
-  <style>
+  <style scoped>
     p {
       font-weight: 900;
     }
   </style>
   <p data-test-multiple-outer>Multiple outer</p>
   {{MultipleInner}}
-  <style>
+  <style scoped>
     p {
       font-style: italic;
     }

--- a/test-app/app/components/outer.hbs
+++ b/test-app/app/components/outer.hbs
@@ -29,12 +29,13 @@
 
 <div>
   <Inner />
+
+  <style>
+    p {
+      text-transform: uppercase;
+    }
+  </style>
 </div>
 
-<style>
-  p {
-    text-transform: uppercase;
-  }
-</style>
 
 {{yield to="block"}}

--- a/test-app/app/components/outer.hbs
+++ b/test-app/app/components/outer.hbs
@@ -1,4 +1,4 @@
-<style>
+<style scoped>
   p { color: blue; }
 
   /* This exercises a bug fix related to base64 encoding of CSS */
@@ -14,7 +14,7 @@
     color: green;
   }
 </style>
-<style data-test-unscoped-root-style unscoped>
+<style data-test-unscoped-root-style>
   p {
     text-align: end;
   }
@@ -31,7 +31,7 @@
   <Inner />
 </div>
 
-<style unscoped>
+<style>
   p {
     text-transform: uppercase;
   }

--- a/test-app/app/components/uses-an-import.gjs
+++ b/test-app/app/components/uses-an-import.gjs
@@ -1,6 +1,6 @@
 const UsesAnImport = <template>
   <p data-test-uses-an-import>I should be green</p>
-  <style>
+  <style scoped>
     @import "./colors.css";
     p {
       color: var(--my-green);

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -16,6 +16,6 @@
 
 <UsesAnImport />
 
-<p class="addon-component">This has a class that makes it underlined because of an unscoped style in an addon.</p>
+<p class="addon-component" data-test-paragraph-with-class-styled-by-addon>This has a class that makes it underlined because of an unscoped style in an addon.</p>
 
 {{outlet}}

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -18,4 +18,6 @@
 
 <p class="addon-component" data-test-paragraph-with-class-styled-by-addon>This has a class that makes it underlined because of an unscoped style in an addon.</p>
 
+<HasInterpolatedStyle />
+
 {{outlet}}

--- a/test-app/tests/acceptance/scoped-css-test.ts
+++ b/test-app/tests/acceptance/scoped-css-test.ts
@@ -92,23 +92,6 @@ module('Acceptance | scoped css', function (hooks) {
     });
   });
 
-  test('unscoped style elements are converted to imports', async function (assert) {
-    await visit('/');
-
-    assert.dom('[data-test-unscoped-root-style]').doesNotExist();
-    assert.dom('[data-test-addon-component-style]').doesNotExist();
-    assert.dom('style[unscoped]').doesNotExist();
-
-    assert.dom('[data-test-global-p]').hasStyle({
-      'text-align': 'end',
-      'text-transform': 'uppercase',
-    });
-
-    assert.dom('.addon-component').hasStyle({
-      'text-decoration': 'underline solid rgb(0, 0, 0)',
-    });
-  });
-
   test('a block can be made non-scoped with the :global pseudo-class', async function (assert) {
     await visit('/');
 

--- a/test-app/tests/acceptance/scoped-css-test.ts
+++ b/test-app/tests/acceptance/scoped-css-test.ts
@@ -128,5 +128,9 @@ module('Acceptance | scoped css', function (hooks) {
       .doesNotHaveStyle({
         textDecoration: 'underline solid rgb(0, 0, 0)',
       });
+
+    assert.dom('[data-test-paragraph-with-class-styled-by-addon]').hasStyle({
+      textDecoration: 'underline solid rgb(0, 0, 0)',
+    });
   });
 });

--- a/test-app/tests/acceptance/scoped-css-test.ts
+++ b/test-app/tests/acceptance/scoped-css-test.ts
@@ -133,4 +133,12 @@ module('Acceptance | scoped css', function (hooks) {
       textDecoration: 'underline solid rgb(0, 0, 0)',
     });
   });
+
+  test('unscoped styles can use interpolation', async function (assert) {
+    await visit('/');
+
+    assert.dom('.interpolated-style-input').hasStyle({
+      color: 'rgb(255, 192, 203)',
+    });
+  });
 });


### PR DESCRIPTION
The change in #32 resulted in an application using `glimmer-scoped-css` being unable to use style interpolation. Previously `unscoped` was an escape valve if you needed style interpolation but in 0.5.0 even `unscoped` styles were extracted to CSS imports as a way to bypass a bug where the host application was inappropriately trying to apply an AST transform on templates imported from an addon.

Instead we’ve decided to shift to requiring authors who want style scoping to call for it explicitly with `<style scoped>…`.

This means unscoped styles don’t need any handling and interpolated styles can work again.