### PR TITLE
Rollup plugin: support app usage

### DIFF
--- a/glimmer-scoped-css/src/rollup.ts
+++ b/glimmer-scoped-css/src/rollup.ts
@@ -3,7 +3,7 @@ import { createHash } from 'crypto';
 import { Plugin } from 'rollup';
 import path from 'path';
 
-export function scopedCSS(srcDir: string): Plugin {
+export function scopedCSS(): Plugin {
   return {
     name: 'scoped-css',
     resolveId(source, importer) {
@@ -11,33 +11,22 @@ export function scopedCSS(srcDir: string): Plugin {
         return null;
       }
       let hash = createHash('md5');
-      let fullSrcDir = path.resolve(srcDir);
-      let localPath = path.relative(fullSrcDir, importer);
       hash.update(source);
       let cssFileName = hash.digest('hex').slice(0, 10) + '.css';
-      let dir = path.dirname(localPath);
-      let cssAndFile = decodeScopedCSSRequest(source);
+      let { css } = decodeScopedCSSRequest(source);
       return {
         id: path.resolve(path.dirname(importer), cssFileName),
         meta: {
           'scoped-css': {
-            css: cssAndFile.css,
-            fileName: path.join(dir, cssFileName),
+            css,
           },
         },
-        external: 'relative',
       };
     },
-    generateBundle() {
-      for (const moduleId of this.getModuleIds()) {
-        let info = this.getModuleInfo(moduleId);
-        if (info?.meta['scoped-css']) {
-          this.emitFile({
-            type: 'asset',
-            fileName: info.meta['scoped-css'].fileName,
-            source: info.meta['scoped-css'].css,
-          });
-        }
+    load(id: string) {
+      let meta = this.getModuleInfo(id)?.meta?.['scoped-css'];
+      if (meta) {
+        return meta.css;
       }
     },
   };


### PR DESCRIPTION
The rollup plugin as currently written only really works for library development, where you want to emit separate CSS files that are imported from your published JS files.

But we'll also want to use it in apps, where those apps are building with Vite (or directly with Rollup).

This PR simplifies the plugin so it just worries about emitting CSS and doesn't care exactly how that CSS gets further processed.

To make this continue to work in v2 addons, I've [adjusted the implementaiton of the keepAssets plugin](https://github.com/embroider-build/embroider/pull/2156) so that it will compose nicely with a plugin like this one that emits CSS. So you'll want to update `@embroider/addon-dev` to a version that includes that PR.

In Vite, it just works with no further configuration since vite handles CSS imports out-of-the-box.

